### PR TITLE
Change multi-process scraper to unified scrapers and refactor mikanani-me without puppeteer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,15 +1,11 @@
-FROM ghcr.io/puppeteer/puppeteer:latest AS base
+FROM node:lts-slim AS base
 WORKDIR /irohalab/indexer
 
 FROM base AS dev
-USER root
-RUN chown -R node:node /irohalab/indexer
-RUN usermod -a -G audio,video node
-USER node
 COPY package.json package-lock.json ./
 RUN npm ci
 RUN mkdir dist
-COPY --chown=node:node . .
+COPY . .
 
 FROM dev AS prod
 RUN npm run build

--- a/Dockerfile.puppeteer
+++ b/Dockerfile.puppeteer
@@ -1,0 +1,21 @@
+FROM ghcr.io/puppeteer/puppeteer:latest AS base
+WORKDIR /home/pptruser
+
+FROM base AS dev
+COPY --chown=pptruser:pptruser package.json ./
+COPY --chown=pptruser:pptruser package-lock.json ./
+RUN npm ci
+COPY --chown=pptruser:pptruser . ./
+
+FROM dev AS prod
+RUN npm run build
+
+USER root
+RUN mkdir -p /opt/google/chrome && \
+    CHROME_PATH=$(find /home/pptruser/.cache/puppeteer -name "chrome" -type f -path "*/chrome-linux64/*" | head -1) && \
+    ln -s "$CHROME_PATH" /opt/google/chrome/chrome
+RUN apt-get update && apt-get install -y --no-install-recommends gosu && rm -rf /var/lib/apt/lists/*
+RUN mkdir -p /mira-bcms && chown pptruser:pptruser /mira-bcms
+COPY docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+ENTRYPOINT ["/docker-entrypoint.sh"]

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -1,10 +1,7 @@
-version: "3.7"
 # before start we need set DOCKER_TAG
 x-web-common:
   &web-common
-  image: "docker.pkg.github.com/irohalab/mira-resource-indexer/indexer:${DOCKER_TAG}"
-  cap_add:
-    - SYS_ADMIN  # ref https://github.com/GoogleChrome/puppeteer/blob/v1.12.1/docs/troubleshooting.md#running-puppeteer-in-docker
+  image: "ghcr.io/irohalab/mira-resource-indexer/indexer:${DOCKER_TAG}"
   logging:
     driver: "json-file"
     options:
@@ -12,102 +9,21 @@ x-web-common:
       max-file: "3"
 
 services:
-  dmhy:
+  indexer:
     << : *web-common
     network_mode: host
-    command: node --title=dmhy dist/main.js
+    command: node --title=indexer dist/main.js
     environment:
       DB_HOST: "${DB_HOST-store}"
       DB_PORT: "${DB_PORT-27017}"
       DB_USER: "${DB_USER-admin}"
       DB_PASS: "${DB_PASS-123456}"
-      INDEXER_MODE: "dmhy"
-      DB_NAME: "dmhy_indexer"
+      MODE_LIST: "${MODE_LIST-dmhy,bangumi_moe,nyaa,acg_rip,mikanani_me}"
       MIN_INTERVAL: "${MIN_INTERVAL-10000}"
       MIN_CHECK_INTERVAL: "${MIN_CHECK_INTERVAL-900000}"
       MIN_FAILED_TASK_CHECK_INTERVAL: "${MIN_FAILED_TASK_CHECK_INTERVAL-1800000}"
       MAX_PAGE_NO: ${MAX_PAGE_NO-5}
       MAX_SEARCH_COUNT: ${MAX_SEARCH_COUNT-100}
-      SERVER_PORT: "4000"
-      SENTRY_DSN: "${SENTRY_DSN}"
-      AMQP_URL: ${AMQP_URL}
-
-  bangumi_moe:
-    << : *web-common
-    network_mode: host
-    command: node --title=bangumi_moe dist/main.js
-    environment:
-      DB_HOST: "${DB_HOST-store}"
-      DB_PORT: "${DB_PORT-27017}"
-      DB_USER: "${DB_USER-admin}"
-      DB_PASS: "${DB_PASS-123456}"
-      INDEXER_MODE: "bangumi_moe"
-      DB_NAME: "bangumi_moe_indexer"
-      MIN_INTERVAL: "${MIN_INTERVAL-10000}"
-      MIN_CHECK_INTERVAL: "${MIN_CHECK_INTERVAL-900000}"
-      MIN_FAILED_TASK_CHECK_INTERVAL: "${MIN_FAILED_TASK_CHECK_INTERVAL-1800000}"
-      MAX_PAGE_NO: ${MAX_PAGE_NO-5}
-      MAX_SEARCH_COUNT: ${MAX_SEARCH_COUNT-100}
-      SERVER_PORT: "4200"
-      SENTRY_DSN: "${SENTRY_DSN}"
-      AMQP_URL: ${AMQP_URL}
-
-  nyaa:
-    << : *web-common
-    network_mode: host
-    command: node --title=nyaa dist/main.js
-    environment:
-      DB_HOST: "${DB_HOST-store}"
-      DB_PORT: "${DB_PORT-27017}"
-      DB_USER: "${DB_USER-admin}"
-      DB_PASS: "${DB_PASS-123456}"
-      INDEXER_MODE: "nyaa"
-      DB_NAME: "nyaa_indexer"
-      MIN_INTERVAL: "${MIN_INTERVAL-10000}"
-      MIN_CHECK_INTERVAL: "${MIN_CHECK_INTERVAL-900000}"
-      MIN_FAILED_TASK_CHECK_INTERVAL: "${MIN_FAILED_TASK_CHECK_INTERVAL-1800000}"
-      MAX_PAGE_NO: ${MAX_PAGE_NO-5}
-      MAX_SEARCH_COUNT: ${MAX_SEARCH_COUNT-100}
-      SERVER_PORT: "4300"
-      SENTRY_DSN: "${SENTRY_DSN}"
-      AMQP_URL: ${AMQP_URL}
-
-  acg_rip:
-    << : *web-common
-    network_mode: host
-    command: node --title=acg_rip dist/main.js
-    environment:
-      DB_HOST: "${DB_HOST-store}"
-      DB_PORT: "${DB_PORT-27017}"
-      DB_USER: "${DB_USER-admin}"
-      DB_PASS: "${DB_PASS-123456}"
-      INDEXER_MODE: "acg_rip"
-      DB_NAME: "acg_rip_indexer"
-      MIN_INTERVAL: "${MIN_INTERVAL-10000}"
-      MIN_CHECK_INTERVAL: "${MIN_CHECK_INTERVAL-900000}"
-      MIN_FAILED_TASK_CHECK_INTERVAL: "${MIN_FAILED_TASK_CHECK_INTERVAL-1800000}"
-      MAX_PAGE_NO: ${MAX_PAGE_NO-5}
-      MAX_SEARCH_COUNT: ${MAX_SEARCH_COUNT-100}
-      SERVER_PORT: "4400"
-      SENTRY_DSN: "${SENTRY_DSN}"
-      AMQP_URL: ${AMQP_URL}
-
-  mikanani_me:
-    <<: *web-common
-    network_mode: host
-    command: node --title=acg_rip dist/main.js
-    environment:
-      DB_HOST: "${DB_HOST-store}"
-      DB_PORT: "${DB_PORT-27017}"
-      DB_USER: "${DB_USER-admin}"
-      DB_PASS: "${DB_PASS-123456}"
-      INDEXER_MODE: "mikanani_me"
-      DB_NAME: "mikanani_indexer"
-      MIN_INTERVAL: "${MIN_INTERVAL-10000}"
-      MIN_CHECK_INTERVAL: "${MIN_CHECK_INTERVAL-900000}"
-      MIN_FAILED_TASK_CHECK_INTERVAL: "${MIN_FAILED_TASK_CHECK_INTERVAL-1800000}"
-      MAX_PAGE_NO: ${MAX_PAGE_NO-5}
-      MAX_SEARCH_COUNT: ${MAX_SEARCH_COUNT-100}
-      SERVER_PORT: "4500"
+      SERVER_PORT: "${SERVER_PORT-4000}"
       SENTRY_DSN: "${SENTRY_DSN}"
       AMQP_URL: ${AMQP_URL}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,5 @@
-version: "3.7"
 services:
   mongo:
-    platform: linux/x86_64
     image: mongo:4.2.2
     network_mode: host
     environment:
@@ -9,19 +7,15 @@ services:
       MONGO_INITDB_ROOT_PASSWORD: "${DB_PASS-123456}"
       MONGO_INITDB_DATABASE: "${DB_NAME-dmhy_indexer}"
   rabbitmq:
-    platform: linux/x86_64
     image: "rabbitmq:4.1"
     network_mode: host
     environment:
       RABBITMQ_DEFAULT_USER: "${RABBITMQ_DEFAULT_USER-ciuser}"
       RABBITMQ_DEFAULT_PASS: "${RABBITMQ_DEFAULT_PASS-cipassword}"
   main:
-    platform: linux/x86_64
     build:
       context: .
       target: dev
-    cap_add:
-      - SYS_ADMIN  # ref https://github.com/GoogleChrome/puppeteer/blob/v1.12.1/docs/troubleshooting.md#running-puppeteer-in-docker 
     image: "indexer"
     network_mode: host
     command: npm run start
@@ -31,11 +25,10 @@ services:
         max-size: "10M"
         max-file: "3"
     environment:
-      INDEXER_MODE: "${INDEXER_MODE-dmhy}"
+      MODE_LIST: "${MODE_LIST-dmhy}"
       DB_HOST: "${DB_HOST-mongo}"
       DB_PORT: "${DB_PORT-27017}"
       DB_USER: "${DB_USER-admin}"
-      DB_NAME: "${DB_NAME-dmhy_indexer}"
       DB_PASS: "${DB_PASS-123456}"
       AUTH_SOURCE: "${AUTH_SOURCE-admin}"
       SERVER_HOST: "${SERVER_HOST-0.0.0.0}"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,18 @@
 {
   "name": "indexer",
-  "version": "1.0.3",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "indexer",
-      "version": "1.0.3",
+      "version": "2.0.0",
       "dependencies": {
-        "@irohalab/mira-shared": "^4.2.2",
+        "@irohalab/mira-shared": "^5.1.2",
         "@sentry/node": "^10.5.0",
         "applicationinsights": "^1.8.7",
-        "axios": "^1.15.0",
-        "cheerio": "^1.1.2",
+        "axios": "^1.15.2",
+        "cheerio": "^1.2.0",
         "express": "^4.21.2",
         "inversify": "^6.0.3",
         "inversify-express-utils": "^6.5.0",
@@ -20,7 +20,7 @@
         "nanoid": "5.0.9",
         "parse-torrent": "^9.1.5",
         "pg": "^8.16.3",
-        "puppeteer": "^24.16.2",
+        "puppeteer-core": "^24.16.2",
         "reflect-metadata": "^0.2.2",
         "saslprep": "^1.0.3",
         "winston": "^3.17.0"
@@ -63,6 +63,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.27.1.tgz",
       "integrity": "sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "@babel/helper-validator-identifier": "^7.27.1",
@@ -256,6 +257,7 @@
       "version": "7.27.1",
       "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.27.1.tgz",
       "integrity": "sha512-D2hP9eA+Sqx1kBZgzxZh0y1trbuU+JoDkiEwqhQ36nodYqJwyEIhPSdMNd7lOm/4io72luTPWH20Yda0xOuUow==",
+      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -302,12 +304,12 @@
       }
     },
     "node_modules/@babel/runtime-corejs3": {
-      "version": "7.28.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.28.3.tgz",
-      "integrity": "sha512-LKYxD2CIfocUFNREQ1yk+dW+8OH8CRqmgatBZYXb+XhuObO8wsDpEoCNri5bKld9cnj8xukqZjxSX8p1YiRF8Q==",
+      "version": "7.29.2",
+      "resolved": "https://registry.npmjs.org/@babel/runtime-corejs3/-/runtime-corejs3-7.29.2.tgz",
+      "integrity": "sha512-Lc94FOD5+0aXhdb0Tdg3RUtqT6yWbI/BbFWvlaSJ3gAb9Ks+99nHRDKADVqC37er4eCB0fHyWT+y+K3QOvJKbw==",
       "license": "MIT",
       "dependencies": {
-        "core-js-pure": "^3.43.0"
+        "core-js-pure": "^3.48.0"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -465,23 +467,23 @@
       }
     },
     "node_modules/@irohalab/mira-shared": {
-      "version": "4.2.2",
-      "resolved": "https://registry.npmjs.org/@irohalab/mira-shared/-/mira-shared-4.2.2.tgz",
-      "integrity": "sha512-5tkuQI3WBfqeEn6P9hY6uEqgKE1hVoTWOxHvk5r/gghFIji1ZkpCEPOViefcIp6DF8+yPL2wwJilywoVso/9GQ==",
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/@irohalab/mira-shared/-/mira-shared-5.1.2.tgz",
+      "integrity": "sha512-T7WG8sY0KO3MOyjN87PIKQTD1lMgmdGz0GHrD016mfeR26bWiFVo+Dbgk2reDTX6R+lOimp99kwdW3Oa3H31OA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@cloudamqp/amqp-client": "^3.2.1",
-        "@mikro-orm/core": "^6.4.16",
-        "@mikro-orm/postgresql": "^6.4.16",
+        "@mikro-orm/core": "^6.6.10",
+        "@mikro-orm/postgresql": "^6.6.10",
         "@sentry/node": "^7.0.0",
-        "amqplib": "^0.10.3",
+        "amqplib": "^0.10.9",
         "inversify": "^6.0.3",
         "inversify-binding-decorators": "^4.0.0",
         "inversify-express-utils": "^6.5.0",
         "inversify-logger-middleware": "^3.1.0",
         "pg": "^8.12.0",
         "pino": "^8.19.0",
-        "rascal": "^19.0.0",
+        "rascal": "^20.1.1",
         "reflect-metadata": "^0.2.2",
         "uuid": "^9.0.1"
       },
@@ -704,17 +706,17 @@
       }
     },
     "node_modules/@mikro-orm/core": {
-      "version": "6.4.16",
-      "resolved": "https://registry.npmjs.org/@mikro-orm/core/-/core-6.4.16.tgz",
-      "integrity": "sha512-BW/My1VlI0R25Eojdh0UiET8J+mEruThksGVfllEnjJQ0uwGs3mm/TbMclv0g+d7Qp4+mpzDQU4+lIo8okHYsw==",
+      "version": "6.6.14",
+      "resolved": "https://registry.npmjs.org/@mikro-orm/core/-/core-6.6.14.tgz",
+      "integrity": "sha512-jKdtf1A2wI2D48phOPJzTc3h7Bev64Ype0FHwbUgHEdZ5VxrCNLKOziFnYqMfPmBe0piVExLaPN2qXgbzCiApw==",
       "license": "MIT",
       "dependencies": {
         "dataloader": "2.2.3",
-        "dotenv": "16.5.0",
+        "dotenv": "17.3.1",
         "esprima": "4.0.1",
-        "fs-extra": "11.3.0",
+        "fs-extra": "11.3.3",
         "globby": "11.1.0",
-        "mikro-orm": "6.4.16",
+        "mikro-orm": "6.6.14",
         "reflect-metadata": "0.2.2"
       },
       "engines": {
@@ -725,13 +727,13 @@
       }
     },
     "node_modules/@mikro-orm/knex": {
-      "version": "6.4.16",
-      "resolved": "https://registry.npmjs.org/@mikro-orm/knex/-/knex-6.4.16.tgz",
-      "integrity": "sha512-2xQodj3uh8maPGsLR7PZMmECtdyLutGxzzrGrrhSX2b+7v9k4MeMazTi4/627hJvivdUpuofypW5zMpw3TU1vQ==",
+      "version": "6.6.14",
+      "resolved": "https://registry.npmjs.org/@mikro-orm/knex/-/knex-6.6.14.tgz",
+      "integrity": "sha512-xQWq9+7TwE8LLul1RkhjB7/0/iCHMlkSmEToVpz+NNFoPj6M32DfY9mhNnM6qPZ/HF50WjpcVgCgi9ADrEBSFA==",
       "license": "MIT",
       "dependencies": {
-        "fs-extra": "11.3.0",
-        "knex": "3.1.0",
+        "fs-extra": "11.3.3",
+        "knex": "3.2.10",
         "sqlstring": "2.3.3"
       },
       "engines": {
@@ -756,13 +758,13 @@
       }
     },
     "node_modules/@mikro-orm/postgresql": {
-      "version": "6.4.16",
-      "resolved": "https://registry.npmjs.org/@mikro-orm/postgresql/-/postgresql-6.4.16.tgz",
-      "integrity": "sha512-i14CvyLrtMhQJMk/X3xTT2Mgc8j0VtSWPqhKBN+euiPxbee4u5k39TlJAly72k3luknFBCzpKCh3ZNSGDZ+j4Q==",
+      "version": "6.6.14",
+      "resolved": "https://registry.npmjs.org/@mikro-orm/postgresql/-/postgresql-6.6.14.tgz",
+      "integrity": "sha512-hgyxpuTaXK0nYhhkmPkz8lx1nzhsqtOQuqQ+oabtyEKuqzPeANRJaV2TczIFYMIczyxKWOylV7g//13qrwqmNQ==",
       "license": "MIT",
       "dependencies": {
-        "@mikro-orm/knex": "6.4.16",
-        "pg": "8.16.0",
+        "@mikro-orm/knex": "6.6.14",
+        "pg": "8.20.0",
         "postgres-array": "3.0.4",
         "postgres-date": "2.1.0",
         "postgres-interval": "4.0.2"
@@ -774,39 +776,6 @@
         "@mikro-orm/core": "^6.0.0"
       }
     },
-    "node_modules/@mikro-orm/postgresql/node_modules/pg": {
-      "version": "8.16.0",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.0.tgz",
-      "integrity": "sha512-7SKfdvP8CTNXjMUzfcVTaI+TDzBEeaUnVwiVGZQD1Hh33Kpev7liQba9uLd4CfN8r9mCVsD0JIpq03+Unpz+kg==",
-      "license": "MIT",
-      "dependencies": {
-        "pg-connection-string": "^2.9.0",
-        "pg-pool": "^3.10.0",
-        "pg-protocol": "^1.10.0",
-        "pg-types": "2.2.0",
-        "pgpass": "1.0.5"
-      },
-      "engines": {
-        "node": ">= 8.0.0"
-      },
-      "optionalDependencies": {
-        "pg-cloudflare": "^1.2.5"
-      },
-      "peerDependencies": {
-        "pg-native": ">=3.0.1"
-      },
-      "peerDependenciesMeta": {
-        "pg-native": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/@mikro-orm/postgresql/node_modules/pg-connection-string": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
-      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
-      "license": "MIT"
-    },
     "node_modules/@mongodb-js/saslprep": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.3.0.tgz",
@@ -814,18 +783,6 @@
       "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
-      }
-    },
-    "node_modules/@noble/hashes": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
-      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^14.21.3 || >=16"
-      },
-      "funding": {
-        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -1369,15 +1326,6 @@
       },
       "peerDependencies": {
         "@opentelemetry/api": "^1.1.0"
-      }
-    },
-    "node_modules/@paralleldrive/cuid2": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.2.2.tgz",
-      "integrity": "sha512-ZOBkgDwEdoYVlSeRbYYXs0S9MejQofiVYoTbKzy/6GQa39/q5tQU2IX46+shYnUkpEl3wc+J6wRlar7r2EK2xA==",
-      "license": "MIT",
-      "dependencies": {
-        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/@prisma/instrumentation": {
@@ -2071,9 +2019,9 @@
       }
     },
     "node_modules/amqplib": {
-      "version": "0.10.8",
-      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.8.tgz",
-      "integrity": "sha512-Tfn1O9sFgAP8DqeMEpt2IacsVTENBpblB3SqLdn0jK2AeX8iyCvbptBc8lyATT9bQ31MsjVwUSQ1g8f4jHOUfw==",
+      "version": "0.10.9",
+      "resolved": "https://registry.npmjs.org/amqplib/-/amqplib-0.10.9.tgz",
+      "integrity": "sha512-jwSftI4QjS3mizvnSnOrPGYiUnm1vI2OP1iXeOUz5pb74Ua0nbf6nPyyTzuiCLEE3fMpaJORXh2K/TQ08H5xGA==",
       "license": "MIT",
       "dependencies": {
         "buffer-more-ints": "~1.0.0",
@@ -2208,12 +2156,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/asap": {
-      "version": "2.0.6",
-      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
-      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
-      "license": "MIT"
-    },
     "node_modules/ast-types": {
       "version": "0.13.4",
       "resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.13.4.tgz",
@@ -2296,15 +2238,64 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.0.tgz",
-      "integrity": "sha512-wWyJDlAatxk30ZJer+GeCWS209sA42X+N5jU2jy6oHTp7ufw8uzUTVFBX9+wTfAlhiJXGS0Bq7X6efruWjuK9Q==",
+      "version": "1.16.1",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.1.tgz",
+      "integrity": "sha512-caYkukvroVPO8KrzuJEb50Hm07KwfBZPEC3VeFHTsqWHvKTsy54hjJz9BS/cdaypROE2rH6xvm9mHX4fgWkr3A==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
+    },
+    "node_modules/axios/node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
+    "node_modules/axios/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/axios/node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/axios/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/axios/node_modules/proxy-from-env": {
       "version": "2.1.0",
@@ -2704,15 +2695,6 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
-    "node_modules/callsites": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-      "integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/camelcase": {
       "version": "5.3.1",
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.3.1.tgz",
@@ -2760,9 +2742,9 @@
       }
     },
     "node_modules/cheerio": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.1.2.tgz",
-      "integrity": "sha512-IkxPpb5rS/d1IiLbHMgfPuS0FgiWTtFIm/Nj+2woXDLTZ7fOT2eqzgYbdMlLweqlHbsZjxEChoVK+7iph7jyQg==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/cheerio/-/cheerio-1.2.0.tgz",
+      "integrity": "sha512-WDrybc/gKFpTYQutKIK6UvfcuxijIZfMfXaYm8NMsPQxSYvf+13fXUJ4rztGGbJcBQ/GF55gvrZ0Bc0bj/mqvg==",
       "license": "MIT",
       "dependencies": {
         "cheerio-select": "^2.1.0",
@@ -2770,11 +2752,11 @@
         "domhandler": "^5.0.3",
         "domutils": "^3.2.2",
         "encoding-sniffer": "^0.2.1",
-        "htmlparser2": "^10.0.0",
+        "htmlparser2": "^10.1.0",
         "parse5": "^7.3.0",
         "parse5-htmlparser2-tree-adapter": "^7.1.0",
         "parse5-parser-stream": "^7.1.2",
-        "undici": "^7.12.0",
+        "undici": "^7.19.0",
         "whatwg-mimetype": "^4.0.0"
       },
       "engines": {
@@ -3045,15 +3027,6 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/component-emitter": {
-      "version": "1.3.1",
-      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
-      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
@@ -3232,65 +3205,15 @@
       "integrity": "sha512-QADzlaHc8icV8I7vbaJXJwod9HWYp8uCqf1xa4OfNu1T7JVxQIrUgOWtHdNDtPiywmFbiS12VjotIXLrKM3orQ==",
       "license": "MIT"
     },
-    "node_modules/cookiejar": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
-      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
-      "license": "MIT"
-    },
     "node_modules/core-js-pure": {
-      "version": "3.45.0",
-      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.45.0.tgz",
-      "integrity": "sha512-OtwjqcDpY2X/eIIg1ol/n0y/X8A9foliaNt1dSK0gV3J2/zw+89FcNG3mPK+N8YWts4ZFUPxnrAzsxs/lf8yDA==",
+      "version": "3.49.0",
+      "resolved": "https://registry.npmjs.org/core-js-pure/-/core-js-pure-3.49.0.tgz",
+      "integrity": "sha512-XM4RFka59xATyJv/cS3O3Kml72hQXUeGRuuTmMYFxwzc9/7C8OYTaIR/Ji+Yt8DXzsFLNhat15cE/JP15HrCgw==",
       "hasInstallScript": true,
       "license": "MIT",
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/core-js"
-      }
-    },
-    "node_modules/cosmiconfig": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-9.0.0.tgz",
-      "integrity": "sha512-itvL5h8RETACmOTFc4UfIyB2RfEHi71Ax6E/PivVxq9NseKbOWpeyHEOIbmAw1rs8Ak0VursQNww7lf7YtUwzg==",
-      "license": "MIT",
-      "dependencies": {
-        "env-paths": "^2.2.1",
-        "import-fresh": "^3.3.0",
-        "js-yaml": "^4.1.0",
-        "parse-json": "^5.2.0"
-      },
-      "engines": {
-        "node": ">=14"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/d-fischer"
-      },
-      "peerDependencies": {
-        "typescript": ">=4.9.5"
-      },
-      "peerDependenciesMeta": {
-        "typescript": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/cosmiconfig/node_modules/argparse": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
-      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
-      "license": "Python-2.0"
-    },
-    "node_modules/cosmiconfig/node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
-      "license": "MIT",
-      "dependencies": {
-        "argparse": "^2.0.1"
-      },
-      "bin": {
-        "js-yaml": "bin/js-yaml.js"
       }
     },
     "node_modules/create-require": {
@@ -3454,16 +3377,6 @@
       "integrity": "sha512-RQ809ykTfJ+dgj9bftdeL2vRVxASAuGU+I9LEx9Ij5TXU5HrgAQVmzi72VA+mkzscE12uzlRv5/tWWv9R9J1SA==",
       "license": "BSD-3-Clause"
     },
-    "node_modules/dezalgo": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
-      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
-      "license": "ISC",
-      "dependencies": {
-        "asap": "^2.0.0",
-        "wrappy": "1"
-      }
-    },
     "node_modules/diagnostic-channel": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/diagnostic-channel/-/diagnostic-channel-0.3.1.tgz",
@@ -3560,9 +3473,9 @@
       }
     },
     "node_modules/dotenv": {
-      "version": "16.5.0",
-      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.5.0.tgz",
-      "integrity": "sha512-m/C+AwOAr9/W1UOIZUo232ejMNnJAJtYQjUbHoNTBNTJSvqzzDh7vnrei3o3r3m9blf6ZoDkvcw0VmozNRFJxg==",
+      "version": "17.3.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-17.3.1.tgz",
+      "integrity": "sha512-IO8C/dzEb6O3F9/twg6ZLXz164a2fhTnEWb95H23Dm4OuN+92NmEAlTrupP9VW6Jm3sO26tQlqyvyi4CsnY9GA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=12"
@@ -3674,24 +3587,6 @@
       },
       "funding": {
         "url": "https://github.com/fb55/entities?sponsor=1"
-      }
-    },
-    "node_modules/env-paths": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/env-paths/-/env-paths-2.2.1.tgz",
-      "integrity": "sha512-+h1lkLKhZMTYjog1VEpJNG7NZJWcuc2DDk/qsqSTRRCOXiLjeQ1d1/udrUGhqMxUgAlwKNZ0cf2uqan5GLuS2A==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/error-ex": {
-      "version": "1.3.2",
-      "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
-      "integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-      "license": "MIT",
-      "dependencies": {
-        "is-arrayish": "^0.2.1"
       }
     },
     "node_modules/es-define-property": {
@@ -3992,16 +3887,10 @@
         "node": ">=6"
       }
     },
-    "node_modules/fast-safe-stringify": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
-      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
-      "license": "MIT"
-    },
     "node_modules/fastq": {
-      "version": "1.19.1",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.19.1.tgz",
-      "integrity": "sha512-GwLTyxkCXjXbxqIhTsMI2Nui8huMPtnxg7krajPJAjnEG/iiOS7i+zCtWGZR9G0NBKbXKh6X9m9UIsYX/N6vvQ==",
+      "version": "1.20.1",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.20.1.tgz",
+      "integrity": "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==",
       "license": "ISC",
       "dependencies": {
         "reusify": "^1.0.4"
@@ -4156,21 +4045,6 @@
         "node": ">= 6"
       }
     },
-    "node_modules/formidable": {
-      "version": "2.1.5",
-      "resolved": "https://registry.npmjs.org/formidable/-/formidable-2.1.5.tgz",
-      "integrity": "sha512-Oz5Hwvwak/DCaXVVUtPn4oLMLLy1CdclLKO1LFgU7XzDpVMUU5UjlSLpGMocyQNNk8F6IJW9M/YdooSn2MRI+Q==",
-      "license": "MIT",
-      "dependencies": {
-        "@paralleldrive/cuid2": "^2.2.2",
-        "dezalgo": "^1.0.4",
-        "once": "^1.4.0",
-        "qs": "^6.11.0"
-      },
-      "funding": {
-        "url": "https://ko-fi.com/tunnckoCore/commissions"
-      }
-    },
     "node_modules/forward-emitter": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/forward-emitter/-/forward-emitter-0.1.1.tgz",
@@ -4223,9 +4097,9 @@
       "license": "MIT"
     },
     "node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
+      "version": "11.3.3",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.3.tgz",
+      "integrity": "sha512-VWSRii4t0AFm6ixFFmLLx1t7wS1gh+ckoa84aOeapGum0h+EZd1EhEumSB+ZdDLnEPuucsVB9oB7cxJHap6Afg==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.0",
@@ -4575,9 +4449,9 @@
       "license": "MIT"
     },
     "node_modules/htmlparser2": {
-      "version": "10.0.0",
-      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.0.0.tgz",
-      "integrity": "sha512-TwAZM+zE5Tq3lrEHvOlvwgj1XLWQCtaaibSN11Q+gGBAS7Y1uZSWwXXRe4iF6OXnaq1riyQAPFOBtYc77Mxq0g==",
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/htmlparser2/-/htmlparser2-10.1.0.tgz",
+      "integrity": "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ==",
       "funding": [
         "https://github.com/fb55/htmlparser2?sponsor=1",
         {
@@ -4589,14 +4463,14 @@
       "dependencies": {
         "domelementtype": "^2.3.0",
         "domhandler": "^5.0.3",
-        "domutils": "^3.2.1",
-        "entities": "^6.0.0"
+        "domutils": "^3.2.2",
+        "entities": "^7.0.1"
       }
     },
     "node_modules/htmlparser2/node_modules/entities": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
-      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.12"
@@ -4745,31 +4619,6 @@
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
       "integrity": "sha512-XXOFtyqDjNDAQxVfYxuF7g9Il/IbWmmlQg2MYKOH8ExIT1qg6xc4zyS3HaEEATgs1btfzxq15ciUiY7gjSXRGQ==",
       "license": "MIT"
-    },
-    "node_modules/import-fresh": {
-      "version": "3.3.1",
-      "resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.3.1.tgz",
-      "integrity": "sha512-TR3KfrTZTYLPB6jUjfx6MF9WcWrHL9su5TObK4ZkYgBdWKPOFoSoQIdEuTuR82pmtxH2spWG9h6etwfr1pLBqQ==",
-      "license": "MIT",
-      "dependencies": {
-        "parent-module": "^1.0.0",
-        "resolve-from": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/import-fresh/node_modules/resolve-from": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-      "integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=4"
-      }
     },
     "node_modules/import-in-the-middle": {
       "version": "1.14.2",
@@ -5041,12 +4890,6 @@
       "engines": {
         "node": ">= 0.10"
       }
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-      "integrity": "sha512-zz06S8t0ozoDXMG+ube26zeCTNXcKIPJZJi8hBrF4idCLms4CG9QtK7qBl1boi5ODzFpjswb5JPmHCbMpjaYzg==",
-      "license": "MIT"
     },
     "node_modules/is-ci": {
       "version": "2.0.0",
@@ -5390,6 +5233,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -5419,12 +5263,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/json-parse-even-better-errors": {
-      "version": "2.3.1",
-      "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
-      "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
-      "license": "MIT"
-    },
     "node_modules/json5": {
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/json5/-/json5-2.2.3.tgz",
@@ -5439,9 +5277,9 @@
       }
     },
     "node_modules/jsonfile": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.0.tgz",
-      "integrity": "sha512-FGuPw30AdOIUTRMC2OMRtQV+jkVj2cfPqSeWXv1NEAJ1qZ5zb1X6z1mFhbfOB/iy3ssJCD+3KuZ8r8C3uVFlAg==",
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
+      "integrity": "sha512-zwOTdL3rFQ/lRdBnntKVOX6k5cKJwEc1HdilT71BWEu7J41gXIB2MRp+vxduPSwZJPWBxEzv4yH1wYLJGUHX4Q==",
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -5451,9 +5289,9 @@
       }
     },
     "node_modules/knex": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/knex/-/knex-3.1.0.tgz",
-      "integrity": "sha512-GLoII6hR0c4ti243gMs5/1Rb3B+AjwMOfjYm97pu0FOQa7JH56hgBxYf5WK2525ceSbBY1cjeZ9yk99GPMB6Kw==",
+      "version": "3.2.10",
+      "resolved": "https://registry.npmjs.org/knex/-/knex-3.2.10.tgz",
+      "integrity": "sha512-oypTHfrc9i72iyxaUQBKHOxhcr0xM65MPf6FpN02nimsftXwzXprIkLjfXdubvhbu4PMWLp023q8o8CYvHSuZw==",
       "license": "MIT",
       "dependencies": {
         "colorette": "2.0.19",
@@ -5464,7 +5302,7 @@
         "get-package-type": "^0.1.0",
         "getopts": "2.3.0",
         "interpret": "^2.2.0",
-        "lodash": "^4.17.21",
+        "lodash": "^4.18.1",
         "pg-connection-string": "2.6.2",
         "rechoir": "^0.8.0",
         "resolve-from": "^5.0.0",
@@ -5476,6 +5314,9 @@
       },
       "engines": {
         "node": ">=16"
+      },
+      "peerDependencies": {
+        "pg-query-stream": "^4.14.0"
       },
       "peerDependenciesMeta": {
         "better-sqlite3": {
@@ -5491,6 +5332,9 @@
           "optional": true
         },
         "pg-native": {
+          "optional": true
+        },
+        "pg-query-stream": {
           "optional": true
         },
         "sqlite3": {
@@ -5538,12 +5382,6 @@
       "dependencies": {
         "immediate": "~3.0.5"
       }
-    },
-    "node_modules/lines-and-columns": {
-      "version": "1.2.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.2.4.tgz",
-      "integrity": "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==",
-      "license": "MIT"
     },
     "node_modules/localforage": {
       "version": "1.10.0",
@@ -5880,9 +5718,9 @@
       }
     },
     "node_modules/mikro-orm": {
-      "version": "6.4.16",
-      "resolved": "https://registry.npmjs.org/mikro-orm/-/mikro-orm-6.4.16.tgz",
-      "integrity": "sha512-a+19cRuEPEJ3qf5Vpv4HO9TAxo/I6/rP1bZT93ln8YtNzAbCrcLC766EG6upLS6Sf7OLqdq0cXs5mUN9ESQQrg==",
+      "version": "6.6.14",
+      "resolved": "https://registry.npmjs.org/mikro-orm/-/mikro-orm-6.6.14.tgz",
+      "integrity": "sha512-SRVEqIrANwlVwZxJUoSXHgpzGgSpaoOiG7XrnYlh7TYehbJRbxE3xIhJNdNw0t7FIItixFUvLnD6A20bvLnUNw==",
       "license": "MIT",
       "engines": {
         "node": ">= 18.12.0"
@@ -6496,36 +6334,6 @@
       "dev": true,
       "license": "BlueOak-1.0.0"
     },
-    "node_modules/parent-module": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
-      "integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-      "license": "MIT",
-      "dependencies": {
-        "callsites": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
-    "node_modules/parse-json": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.2.0.tgz",
-      "integrity": "sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==",
-      "license": "MIT",
-      "dependencies": {
-        "@babel/code-frame": "^7.0.0",
-        "error-ex": "^1.3.1",
-        "json-parse-even-better-errors": "^2.3.0",
-        "lines-and-columns": "^1.1.6"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/parse-torrent": {
       "version": "9.1.5",
       "resolved": "https://registry.npmjs.org/parse-torrent/-/parse-torrent-9.1.5.tgz",
@@ -6711,14 +6519,14 @@
       "license": "MIT"
     },
     "node_modules/pg": {
-      "version": "8.16.3",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.3.tgz",
-      "integrity": "sha512-enxc1h0jA/aq5oSDMvqyW3q89ra6XIIDZgCX9vkMrnz5DFTw/Ny3Li2lFQ+pt3L6MCgm/5o2o8HW9hiJji+xvw==",
+      "version": "8.20.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.20.0.tgz",
+      "integrity": "sha512-ldhMxz2r8fl/6QkXnBD3CR9/xg694oT6DZQ2s6c/RI28OjtSOpxnPrUCGOBJ46RCUxcWdx3p6kw/xnDHjKvaRA==",
       "license": "MIT",
       "dependencies": {
-        "pg-connection-string": "^2.9.1",
-        "pg-pool": "^3.10.1",
-        "pg-protocol": "^1.10.3",
+        "pg-connection-string": "^2.12.0",
+        "pg-pool": "^3.13.0",
+        "pg-protocol": "^1.13.0",
         "pg-types": "2.2.0",
         "pgpass": "1.0.5"
       },
@@ -6726,7 +6534,7 @@
         "node": ">= 16.0.0"
       },
       "optionalDependencies": {
-        "pg-cloudflare": "^1.2.7"
+        "pg-cloudflare": "^1.3.0"
       },
       "peerDependencies": {
         "pg-native": ">=3.0.1"
@@ -6738,9 +6546,9 @@
       }
     },
     "node_modules/pg-cloudflare": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.7.tgz",
-      "integrity": "sha512-YgCtzMH0ptvZJslLM1ffsY4EuGaU0cx4XSdXLRFae8bPP4dS5xL1tNB3k2o/N64cHJpwU7dxKli/nZ2lUa5fLg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.3.0.tgz",
+      "integrity": "sha512-6lswVVSztmHiRtD6I8hw4qP/nDm1EJbKMRhf3HCYaqud7frGysPv7FYJ5noZQdhQtN2xJnimfMtvQq21pdbzyQ==",
       "license": "MIT",
       "optional": true
     },
@@ -6760,18 +6568,18 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.10.1",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.1.tgz",
-      "integrity": "sha512-Tu8jMlcX+9d8+QVzKIvM/uJtp07PKr82IUOYEphaWcoBhIYkoHpLXN3qO59nAI11ripznDsEzEv8nUxBVWajGg==",
+      "version": "3.13.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.13.0.tgz",
+      "integrity": "sha512-gB+R+Xud1gLFuRD/QgOIgGOBE2KCQPaPwkzBBGC9oG69pHTkhQeIuejVIk3/cnDyX39av2AxomQiyPT13WKHQA==",
       "license": "MIT",
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.10.3",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.3.tgz",
-      "integrity": "sha512-6DIBgBQaTKDJyxnXaLiLR8wBpQQcGWuAESkRBX/t6OwA8YsqP+iVSiond2EDy6Y/dsGk8rh/jtax3js5NeV7JQ==",
+      "version": "1.13.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.13.0.tgz",
+      "integrity": "sha512-zzdvXfS6v89r6v7OcFCHfHlyG/wvry1ALxZo4LqgUoy7W9xhBDMaqOuMiF3qEV45VqsN6rdlcehHrfDtlCPc8w==",
       "license": "MIT"
     },
     "node_modules/pg-types": {
@@ -6821,9 +6629,9 @@
       }
     },
     "node_modules/pg/node_modules/pg-connection-string": {
-      "version": "2.9.1",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.1.tgz",
-      "integrity": "sha512-nkc6NpDcvPVpZXxrreI/FOtX3XemeLl8E0qFr6F2Lrm/I8WOnaWNhIPK2Z7OHpw7gh5XJThi6j6ppgNoaT1w4w==",
+      "version": "2.12.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.12.0.tgz",
+      "integrity": "sha512-U7qg+bpswf3Cs5xLzRqbXbQl85ng0mfSV/J0nnA31MCLgvEaAo7CIhmeyrmJpOr7o+zm0rXK+hNnT5l9RHkCkQ==",
       "license": "MIT"
     },
     "node_modules/pgpass": {
@@ -6839,6 +6647,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
       "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
       "license": "ISC"
     },
     "node_modules/picomatch": {
@@ -7078,27 +6887,6 @@
         "node": ">=6"
       }
     },
-    "node_modules/puppeteer": {
-      "version": "24.16.2",
-      "resolved": "https://registry.npmjs.org/puppeteer/-/puppeteer-24.16.2.tgz",
-      "integrity": "sha512-eNjKzwjITM4Lvho6iHb+VQamadUBgc8TsjAApsKi5N8DXipxAaAZWssBOFsrIOLo4eYWYj0Qk5gmr4wBSqzJWw==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@puppeteer/browsers": "2.10.6",
-        "chromium-bidi": "7.3.1",
-        "cosmiconfig": "^9.0.0",
-        "devtools-protocol": "0.0.1475386",
-        "puppeteer-core": "24.16.2",
-        "typed-query-selector": "^2.12.0"
-      },
-      "bin": {
-        "puppeteer": "lib/cjs/puppeteer/node/cli.js"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "node_modules/puppeteer-core": {
       "version": "24.16.2",
       "resolved": "https://registry.npmjs.org/puppeteer-core/-/puppeteer-core-24.16.2.tgz",
@@ -7196,9 +6984,9 @@
       }
     },
     "node_modules/rascal": {
-      "version": "19.0.0",
-      "resolved": "https://registry.npmjs.org/rascal/-/rascal-19.0.0.tgz",
-      "integrity": "sha512-lzzTZeOpHarX2+oyPRM7yuTZ4Fk/Uy907Yr+xtPV0ww+ekiErswSHiF5NlczuMcWdzXa8hEwqcLYxV9k6sSDIw==",
+      "version": "20.1.1",
+      "resolved": "https://registry.npmjs.org/rascal/-/rascal-20.1.1.tgz",
+      "integrity": "sha512-7seygN1P9tHSNQRAEzJbwrFpByH5KAzqV50WxrcfVBkyQW80WeSk8P4mpoGDn7c61q98mCKW8XjfthkcQHFJAg==",
       "license": "MIT",
       "dependencies": {
         "async": "^3.2.4",
@@ -7209,7 +6997,6 @@
         "lru-cache": "^7.10.1",
         "safe-json-parse": "^4.0.0",
         "stashback": "^2.0.1",
-        "superagent": "^8.0.9",
         "uuid": "^8.3.2",
         "xregexp": "^5.1.0"
       },
@@ -7221,9 +7008,9 @@
       }
     },
     "node_modules/rascal/node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -7256,6 +7043,7 @@
       "version": "8.3.2",
       "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
       "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+      "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
       "license": "MIT",
       "bin": {
         "uuid": "dist/bin/uuid"
@@ -8262,9 +8050,9 @@
       }
     },
     "node_modules/stashback/node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -8458,75 +8246,6 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/superagent": {
-      "version": "8.1.2",
-      "resolved": "https://registry.npmjs.org/superagent/-/superagent-8.1.2.tgz",
-      "integrity": "sha512-6WTxW1EB6yCxV5VFOIPQruWGHqc3yI7hEmZK6h+pyk69Lk/Ut7rLUY6W/ONF2MjBuGjvmMiIpsrVJ2vjrHlslA==",
-      "deprecated": "Please upgrade to superagent v10.2.2+, see release notes at https://github.com/forwardemail/superagent/releases/tag/v10.2.2 - maintenance is supported by Forward Email @ https://forwardemail.net",
-      "license": "MIT",
-      "dependencies": {
-        "component-emitter": "^1.3.0",
-        "cookiejar": "^2.1.4",
-        "debug": "^4.3.4",
-        "fast-safe-stringify": "^2.1.1",
-        "form-data": "^4.0.0",
-        "formidable": "^2.1.2",
-        "methods": "^1.1.2",
-        "mime": "2.6.0",
-        "qs": "^6.11.0",
-        "semver": "^7.3.8"
-      },
-      "engines": {
-        "node": ">=6.4.0 <13 || >=14"
-      }
-    },
-    "node_modules/superagent/node_modules/debug": {
-      "version": "4.4.1",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
-      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/superagent/node_modules/mime": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
-      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
-      "engines": {
-        "node": ">=4.0.0"
-      }
-    },
-    "node_modules/superagent/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
-    "node_modules/superagent/node_modules/semver": {
-      "version": "7.7.2",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.2.tgz",
-      "integrity": "sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==",
-      "license": "ISC",
-      "bin": {
-        "semver": "bin/semver.js"
-      },
-      "engines": {
-        "node": ">=10"
       }
     },
     "node_modules/supports-color": {
@@ -8975,7 +8694,7 @@
       "version": "5.9.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.2.tgz",
       "integrity": "sha512-CWBzXQrc/qOkhidw1OzBTQuYRbfyxDXJMVJ1XNwUHGROVmuaeiEm3OslpZ1RV96d7SKKjZKrSJu3+t/xlw3R9A==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "indexer",
-  "version": "1.0.4",
+  "version": "2.0.0",
   "scripts": {
     "clean:dist": "rimraf dist/*",
     "build": "npm run clean:dist && tsc && cp package.json dist",

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     "check-coverage": "nyc npm run test"
   },
   "dependencies": {
-    "@irohalab/mira-shared": "^4.2.2",
+    "@irohalab/mira-shared": "^5.1.2",
     "@sentry/node": "^10.5.0",
     "applicationinsights": "^1.8.7",
-    "axios": "^1.15.0",
-    "cheerio": "^1.1.2",
+    "axios": "^1.15.2",
+    "cheerio": "^1.2.0",
     "express": "^4.21.2",
     "inversify": "^6.0.3",
     "inversify-express-utils": "^6.5.0",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "nanoid": "5.0.9",
     "parse-torrent": "^9.1.5",
     "pg": "^8.16.3",
-    "puppeteer": "^24.16.2",
+    "puppeteer-core": "^24.16.2",
     "reflect-metadata": "^0.2.2",
     "saslprep": "^1.0.3",
     "winston": "^3.17.0"

--- a/src/TYPES_IDX.ts
+++ b/src/TYPES_IDX.ts
@@ -21,11 +21,15 @@ import { EventLog } from './entity/EventLog';
 
 export const TYPES_IDX = {
     ItemStorage: Symbol.for('ItemStorage'),
+    ItemStorageMap: Symbol.for('ItemStorageMap'),
     Scraper: Symbol.for('Scraper'),
     TaskStorage: Symbol.for('TaskStorage'),
     TaskTimingFactory: Symbol.for('TaskTiming'),
     ThrottleStore: Symbol.for('ThrottleStore'),
-    EventLogStore: Symbol.for('EventLogStore')
+    EventLogStore: Symbol.for('EventLogStore'),
+    Mode: Symbol.for('Mode'),
+    DBName: Symbol.for('DBName'),
+    AsyncMutex: Symbol.for('AsyncMutex')
 };
 
 export type LogType = 'info' | 'warn' | 'error';
@@ -72,6 +76,7 @@ export interface ThrottleStore {
     setLastMainTaskTime(): Promise<void>;
     getLastFailedTaskTime(): Promise<number>
     setLastFailedTaskTime(): Promise<void>;
+    tryClaimTaskTime(name: string, minInterval: number): Promise<boolean>;
 }
 
 export interface EventLogStore {
@@ -88,6 +93,7 @@ export interface EventLogStore {
 }
 
 export interface Scraper {
+    initMQ(): Promise<void>;
     start(): Promise<any>;
     end(): Promise<any>;
 

--- a/src/main.ts
+++ b/src/main.ts
@@ -21,6 +21,7 @@ import { NyaaScraper } from './scraper/nyaa';
 import { AcgRipScraper } from './scraper/acg-rip';
 import { RESTServer } from './server';
 import { DatabaseService } from './service/database-service';
+import { MongoClientProvider } from './service/mongo-client-provider';
 import { MongodbItemStore } from './storage/mongodb-item-store';
 import { MongodbTaskStore } from './storage/mongodb-task-store';
 import { TaskOrchestra } from './task/task-orchestra';
@@ -35,63 +36,100 @@ import { ConfigManagerImpl } from './utils/config-manager-impl';
 import { ACG_RIP, BANGUMI_MOE, ConfigManager, DMHY, MIKANANI_ME, NYAA } from './utils/config-manager';
 import { hostname } from 'os';
 import { MongodbEventLogStore } from './storage/mongodb-event-log-store';
-import { MikananiMe } from './scraper/mikanani-me';
+import { MikananiMeLight } from './scraper/mikanani-me-light';
 import { DmhyLightScraper } from './scraper/dmhy-light';
+import { AsyncMutex } from './utils/async-mutex';
+import { ScraperCoordinator } from './task/scraper-coordinator';
 
-/* Initialize container */
+/* ===== Root container: shared infrastructure only ===== */
 const container = new Container();
 container.bind<ConfigManager>(TYPES.ConfigManager).to(ConfigManagerImpl).inSingletonScope();
 
 const config = container.get<ConfigManager>(TYPES.ConfigManager);
-config.prepare();
 
 // tslint:disable-next-line
 const { version } = require('../package.json');
 container.bind<Sentry>(TYPES.Sentry).to(SentryImpl).inSingletonScope();
 const sentry = container.get<Sentry>(TYPES.Sentry);
 
-sentry.setup(`${config.getMode()}_${hostname()}`, 'indexer', version);
+sentry.setup(`${hostname()}`, 'indexer', version);
 
-/* bind TaskStorage */
-container.bind<DatabaseService>(DatabaseService).toSelf().inSingletonScope();
-container.bind<TaskQueue>(TYPES_IDX.TaskStorage).to(MongodbTaskStore).inSingletonScope();
-container.bind<ThrottleStore>(TYPES_IDX.ThrottleStore).to(MongodbThrottleStore).inSingletonScope();
-container.bind<EventLogStore>(TYPES_IDX.EventLogStore).to(MongodbEventLogStore).inSingletonScope();
+/* Shared MongoClient (single connection pool for all modes) */
+container.bind<MongoClientProvider>(MongoClientProvider).toSelf().inSingletonScope();
 
-/* bind message queue */
+/* Shared message queue (single AMQP connection) */
 container.bind<RabbitMQService>(TYPES.RabbitMQService).to(RascalImpl).inSingletonScope();
 
-/* bind TaskOrchestra */
+/* Shared task timing factory */
 container.bind<interfaces.Factory<number>>(TYPES_IDX.TaskTimingFactory).toFactory<number>(TaskTiming);
-container.bind<TaskOrchestra>(TaskOrchestra).toSelf().inTransientScope();
 
-switch (config.getMode()) {
-    case DMHY:
-        container.bind<ItemStorage<number>>(TYPES_IDX.ItemStorage).to(MongodbItemStore).inSingletonScope();
-        container.bind<Scraper>(TYPES_IDX.Scraper).to(DmhyLightScraper).inSingletonScope();
-        break;
-    case BANGUMI_MOE:
-        container.bind<ItemStorage<string>>(TYPES_IDX.ItemStorage).to(MongodbItemStore).inSingletonScope();
-        container.bind<Scraper>(TYPES_IDX.Scraper).to(BangumiMoe).inSingletonScope();
-        break;
-    case NYAA:
-        container.bind<ItemStorage<number>>(TYPES_IDX.ItemStorage).to(MongodbItemStore).inSingletonScope();
-        container.bind<Scraper>(TYPES_IDX.Scraper).to(NyaaScraper).inSingletonScope();
-        break;
-    case ACG_RIP:
-        container.bind<ItemStorage<number>>(TYPES_IDX.ItemStorage).to(MongodbItemStore).inSingletonScope();
-        container.bind<Scraper>(TYPES_IDX.Scraper).to(AcgRipScraper).inSingletonScope();
-        break;
-    case MIKANANI_ME:
-        container.bind<ItemStorage<string>>(TYPES_IDX.ItemStorage).to(MongodbItemStore).inSingletonScope();
-        container.bind<Scraper>(TYPES_IDX.Scraper).to(MikananiMe).inSingletonScope();
-        break;
-    default:
-        throw new Error('Mode is not supported yet');
+/* Shared AsyncMutex: ensures only one scraper task runs at a time */
+container.bind<AsyncMutex>(TYPES_IDX.AsyncMutex).to(AsyncMutex).inSingletonScope();
+
+/* ===== Child containers: one per mode with ALL mode-dependent services ===== */
+const modes = config.getModeList();
+const childContainers: Container[] = [];
+
+for (const mode of modes) {
+    const child = container.createChild();
+
+    /* Mode identifier */
+    child.bind<string>(TYPES_IDX.Mode).toConstantValue(mode);
+    child.bind<string>(TYPES_IDX.DBName).toConstantValue(`${mode}_indexer`);
+
+    /* Per-mode database service (shares MongoClient from parent) */
+    child.bind<DatabaseService>(DatabaseService).toSelf().inSingletonScope();
+
+    /* Per-mode storage (each operates on its own database) */
+    child.bind<TaskQueue>(TYPES_IDX.TaskStorage).to(MongodbTaskStore).inSingletonScope();
+    child.bind<ThrottleStore>(TYPES_IDX.ThrottleStore).to(MongodbThrottleStore).inSingletonScope();
+    child.bind<EventLogStore>(TYPES_IDX.EventLogStore).to(MongodbEventLogStore).inSingletonScope();
+
+    /* Per-mode task orchestration */
+    child.bind<TaskOrchestra>(TaskOrchestra).toSelf().inSingletonScope();
+
+    /* Per-mode scraper + item storage */
+    switch (mode) {
+        case DMHY:
+            child.bind<ItemStorage<number>>(TYPES_IDX.ItemStorage).to(MongodbItemStore).inSingletonScope();
+            child.bind<Scraper>(TYPES_IDX.Scraper).to(DmhyLightScraper).inSingletonScope();
+            break;
+        case BANGUMI_MOE:
+            child.bind<ItemStorage<string>>(TYPES_IDX.ItemStorage).to(MongodbItemStore).inSingletonScope();
+            child.bind<Scraper>(TYPES_IDX.Scraper).to(BangumiMoe).inSingletonScope();
+            break;
+        case NYAA:
+            child.bind<ItemStorage<number>>(TYPES_IDX.ItemStorage).to(MongodbItemStore).inSingletonScope();
+            child.bind<Scraper>(TYPES_IDX.Scraper).to(NyaaScraper).inSingletonScope();
+            break;
+        case ACG_RIP:
+            child.bind<ItemStorage<number>>(TYPES_IDX.ItemStorage).to(MongodbItemStore).inSingletonScope();
+            child.bind<Scraper>(TYPES_IDX.Scraper).to(AcgRipScraper).inSingletonScope();
+            break;
+        case MIKANANI_ME:
+            child.bind<ItemStorage<string>>(TYPES_IDX.ItemStorage).to(MongodbItemStore).inSingletonScope();
+            child.bind<Scraper>(TYPES_IDX.Scraper).to(MikananiMeLight).inSingletonScope();
+            break;
+        default:
+            throw new Error('Mode is not supported yet');
+    }
+
+    childContainers.push(child);
 }
 
-const scraper = container.get<Scraper>(TYPES_IDX.Scraper);
-const databaseService = container.get<DatabaseService>(DatabaseService);
+/* ===== Build the coordinator from all child containers ===== */
+const coordinator = new ScraperCoordinator();
+const itemStorageMap = new Map<string, ItemStorage<any>>();
+for (let i = 0; i < modes.length; i++) {
+    const scraper = childContainers[i].get<Scraper>(TYPES_IDX.Scraper);
+    coordinator.addScraper(modes[i], scraper);
+    itemStorageMap.set(modes[i], childContainers[i].get<ItemStorage<any>>(TYPES_IDX.ItemStorage));
+}
+
+/* Bind the storage map in root container for REST API */
+container.bind<Map<string, ItemStorage<any>>>(TYPES_IDX.ItemStorageMap).toConstantValue(itemStorageMap);
+
+const mongoClientProvider = container.get<MongoClientProvider>(MongoClientProvider);
 
 process.on('unhandledRejection', (reason) => {
     logger.error('unhandled_rejection', { reason: String(reason), stack: (reason as Error)?.stack });
@@ -107,21 +145,31 @@ process.on('uncaughtException', (err) => {
 // catches Ctrl+C event
 process.on('SIGINT', async () => {
     logger.info('stopping scrapper and store...');
-    await scraper.end();
-    await databaseService.onEnd();
+    await coordinator.end();
+    await mongoClientProvider.close();
     process.exit();
 });
 
 (async () => {
-    await databaseService.onStart();
-    await scraper.start();
+    /* Connect shared MongoClient first */
+    await mongoClientProvider.connect();
+
+    /* Initialize each mode's database service */
+    for (const child of childContainers) {
+        const dbService = child.get<DatabaseService>(DatabaseService);
+        await dbService.onStart();
+    }
+
+    /* Start all scrapers (each with its own TaskOrchestra, serialized via AsyncMutex) */
+    await coordinator.start();
 })().catch((err) => {
     logger.error('startup_error', { message: err.message, stack: err.stack });
     sentry.capture(err);
     process.exit(1);
 });
 
-sentry.capture(`starting ${config.getMode()} scraper, REST service listening ${config.getServerHost()}:${config.getServerPort()}`);
+sentry.capture(`starting scraper, REST service listening ${config.getServerHost()}:${config.getServerPort()}`);
 
+/* REST server uses root container (ItemStorageMap is bound there) */
 const server = new RESTServer(container, config);
 server.start();

--- a/src/rest-api/items-query.ts
+++ b/src/rest-api/items-query.ts
@@ -15,24 +15,31 @@
  */
 
 import { inject } from 'inversify';
-import { controller, httpGet, queryParam, BaseHttpController, interfaces } from 'inversify-express-utils';
+import { controller, httpGet, queryParam, requestParam, BaseHttpController, interfaces } from 'inversify-express-utils';
 import { ItemStorage, TYPES_IDX } from '../TYPES_IDX';
 import { JsonResultFactory } from '@irohalab/mira-shared';
 
-@controller('/item')
-export class ItemsQuery<T> extends BaseHttpController implements interfaces.Controller {
+@controller('/:mode/item')
+export class ItemsQuery extends BaseHttpController implements interfaces.Controller {
 
-    constructor(@inject(TYPES_IDX.ItemStorage) private _storage: ItemStorage<T>) {
+    constructor(@inject(TYPES_IDX.ItemStorageMap) private _storageMap: Map<string, ItemStorage<any>>) {
         super();
     }
 
     @httpGet('/')
-    public async search(@queryParam('keyword') keyword: string): Promise<interfaces.IHttpActionResult> {
+    public async search(
+        @requestParam('mode') mode: string,
+        @queryParam('keyword') keyword: string
+    ): Promise<interfaces.IHttpActionResult> {
+        const storage = this._storageMap.get(mode);
+        if (!storage) {
+            return this.json({ error: `Unknown mode: ${mode}` }, 404);
+        }
         if (!keyword) {
             return this.badRequest('keyword required');
         }
         try {
-            let items = await this._storage.searchItem(keyword);
+            let items = await storage.searchItem(keyword);
             if (!items) {
                 items = [];
             }

--- a/src/scraper/abstract/base-scraper.ts
+++ b/src/scraper/abstract/base-scraper.ts
@@ -78,6 +78,10 @@ export abstract class BaseScraper<T> implements Scraper {
         }
     }
 
+    public async initMQ(): Promise<void> {
+        await this._taskOrchestra.initMQ();
+    }
+
     public async start(): Promise<any> {
         // await this._taskOrchestra.queue(new MainTask(TaskType.MAIN));
         await this._taskOrchestra.start(this);

--- a/src/scraper/abstract/base-scraper.ts
+++ b/src/scraper/abstract/base-scraper.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { ProtocolError, TimeoutError } from 'puppeteer';
+import { TimeoutError } from 'puppeteer-core';
 import { Item } from '../../entity/Item';
 import { MainTask } from '../../task/main-task';
 import { SubTask } from '../../task/sub-task';

--- a/src/scraper/dmhy.ts
+++ b/src/scraper/dmhy.ts
@@ -15,7 +15,7 @@
  */
 
 import { inject, injectable } from 'inversify';
-import { Browser, HTTPRequest, launch, Page } from 'puppeteer';
+import { Browser, HTTPRequest, launch, Page } from 'puppeteer-core';
 import { resolve } from 'url';
 import { promises } from 'fs';
 import { downloadFile } from '../utils/download';
@@ -132,7 +132,7 @@ export class DmhyScraper extends BaseScraper<number> {
             let items = [];
             for (let tr of trList) {
                 let item = new Item<number>();
-                item.uri = trimDomain(await page.evaluate(el => {
+                item.uri = trimDomain(await page.evaluate((el: Element) => {
                     let titleLink = el.querySelector('td.title>a');
                     if (titleLink && titleLink.getAttribute('href')) {
                         return titleLink.getAttribute('href').trim();
@@ -146,10 +146,10 @@ export class DmhyScraper extends BaseScraper<number> {
                 item.type = new ItemType<number>();
                 item.type.id = this.getIdFromUri(
                     await page.evaluate(
-                        el => el.querySelector('td:nth-child(2) > a').getAttribute('href'), tr),
+                        (el: Element) => el.querySelector('td:nth-child(2) > a').getAttribute('href'), tr),
                     /\/topics\/list\/sort_id\/(\d+)/);
                 item.type.name = await page.evaluate(
-                    el => el.querySelector('td:nth-child(2) > a font').textContent.trim(), tr);
+                    (el: Element) => el.querySelector('td:nth-child(2) > a font').textContent.trim(), tr);
             }
             let newIds = await this._store.filterItemNotStored(items.map(item => item.id));
             let newItems = items.filter(item => {
@@ -189,7 +189,7 @@ export class DmhyScraper extends BaseScraper<number> {
                 return 404;
             }
 
-            item.title = await page.evaluate(el => {
+            item.title = await page.evaluate((el: Element) => {
                 const h3El = el.querySelector('.topic-main > .topic-title > h3');
                 return h3El.textContent.trim();
             }, mainArea);
@@ -197,10 +197,10 @@ export class DmhyScraper extends BaseScraper<number> {
             let publisherElement = await mainArea.$('.user-sidebar > .avatar.box:nth-child(1) > p:nth-child(2) > a');
             // console.log(publisherElement.toString());
             item.publisher = new Publisher<number>();
-            item.publisher.id = this.getIdFromUri(await page.evaluate(el => el.getAttribute('href'), publisherElement),
+            item.publisher.id = this.getIdFromUri(await page.evaluate((el: Element) => el.getAttribute('href'), publisherElement),
                 /\/topics\/list\/user_id\/(\d+)/);
             // console.log(item.publisher);
-            item.publisher.name = await page.evaluate(el => {
+            item.publisher.name = await page.evaluate((el: Element) => {
                 let name = el.textContent;
                 if (name) {
                     name = name.trim();
@@ -211,9 +211,9 @@ export class DmhyScraper extends BaseScraper<number> {
             let teamElement = await mainArea.$('.user-sidebar > .avatar.box:nth-child(2) > p:nth-child(2) > a');
             if (teamElement) {
                 item.team = new Team<number>();
-                item.team.id = this.getIdFromUri(await page.evaluate(el => el.getAttribute('href'), teamElement),
+                item.team.id = this.getIdFromUri(await page.evaluate((el: Element) => el.getAttribute('href'), teamElement),
                     /\/topics\/list\/team_id\/(\d+)/);
-                item.team.name = await page.evaluate(el => {
+                item.team.name = await page.evaluate((el: Element) => {
                     let name = el.textContent;
                     if (name) {
                         name = name.trim();
@@ -223,7 +223,7 @@ export class DmhyScraper extends BaseScraper<number> {
                 // console.log(item.team);
             }
             let resourceInfoElement = await mainArea.$('.info.resource-info.right > ul');
-            item.timestamp = toUTCDate(await page.evaluate(el => {
+            item.timestamp = toUTCDate(await page.evaluate((el: Element) => {
                 const spanEl = el.querySelector('li:nth-child(2) > span');
                 let timeStr = spanEl.textContent;
                 if (timeStr) {
@@ -233,11 +233,11 @@ export class DmhyScraper extends BaseScraper<number> {
             }, resourceInfoElement), 8);
             // console.log(item.timestamp);
             let btResourceElement = await mainArea.$('#tabs-1');
-            item.torrent_url = resolve('https://', await page.evaluate(el => {
+            item.torrent_url = resolve('https://', await page.evaluate((el: Element) => {
                 const anchor = el.querySelector('p:nth-child(1) > a');
                 return anchor.getAttribute('href');
             }, btResourceElement));
-            item.magnet_uri = await page.evaluate(el => {
+            item.magnet_uri = await page.evaluate((el: Element) => {
                 const anchor = el.querySelector('#a_magnet');
                 return anchor.getAttribute('href');
             }, btResourceElement);

--- a/src/scraper/mikanani-me-light.ts
+++ b/src/scraper/mikanani-me-light.ts
@@ -1,0 +1,187 @@
+/*
+ * Copyright 2020 IROHA LAB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import Axios from 'axios';
+import { inject, injectable } from 'inversify';
+import { unlink } from 'fs/promises';
+import { downloadFile } from '../utils/download';
+import { getTorrentInfo } from '../utils/torrent-utils';
+import { Item } from '../entity/Item';
+import { Publisher } from '../entity/publisher';
+import { Team } from '../entity/Team';
+import { TaskOrchestra } from '../task/task-orchestra';
+import { EventLogStore, ItemStorage, TYPES_IDX } from '../TYPES_IDX';
+import { toUTCDate } from '../utils/normalize';
+import { BaseScraper } from './abstract/base-scraper';
+import { logger } from '../utils/logger-factory';
+import { Sentry, TYPES } from '@irohalab/mira-shared';
+import { ConfigManager } from '../utils/config-manager';
+import cheerio = require('cheerio');
+
+@injectable()
+export class MikananiMeLight extends BaseScraper<string> {
+    private static _host = 'https://mikanani.me';
+
+    constructor(
+        @inject(TYPES_IDX.ItemStorage) store: ItemStorage<string>,
+        @inject(TYPES_IDX.EventLogStore) eventLogStore: EventLogStore,
+        @inject(TaskOrchestra) taskOrchestra: TaskOrchestra,
+        @inject(TYPES.Sentry) sentry: Sentry,
+        @inject(TYPES.ConfigManager) config: ConfigManager
+    ) {
+        super(taskOrchestra, config, store, eventLogStore, sentry);
+    }
+
+    public async executeMainTask(pageNo?: number): Promise<{ items: Item<string>[], hasNext: boolean }> {
+        try {
+            let listPageUrl = MikananiMeLight._host + '/Home/Classic';
+            if (pageNo) {
+                listPageUrl += '/' + pageNo;
+            }
+            logger.info('execute_main_task', {
+                pageNo
+            });
+            const resp = await Axios.get(listPageUrl);
+            const $ = cheerio.load(resp.data);
+            const trList = Array.from($('#sk-body > .table tbody > tr'));
+            let items: Item<string>[] = [];
+            for (const tr of trList) {
+                const item = new Item<string>();
+                const titleLink = $('td:nth-child(3) > a.magnet-link-wrap', tr);
+                const href = titleLink.attr('href');
+                item.uri = href ? href.trim() : null;
+                item.id = this.getIdFromUri(item.uri);
+                items.push(item);
+            }
+            let newIds = await this._store.filterItemNotStored(items.map(item => item.id));
+            let newItems: Item<string>[] = [];
+            let newIdx = items.map((item) => {
+                return newIds.includes(item.id);
+            });
+
+            for (let i = 0; i < trList.length; i++) {
+                if (!newIdx[i]) {
+                    continue;
+                }
+                const tr = trList[i];
+                const item = new Item<string>();
+
+                // datetime
+                const dateTextTd = $('td:first-child', tr);
+                let dateText = dateTextTd.length ? dateTextTd.text() : '';
+                if (dateText) {
+                    const today = new Date();
+                    const yesterday = new Date(today);
+                    yesterday.setDate(today.getDate() - 1);
+                    const todayDateStr = `${today.getFullYear()}/${today.getMonth() + 1}/${today.getDate()}`;
+                    const yesterdayDateStr = `${yesterday.getFullYear()}/${yesterday.getMonth() + 1}/${yesterday.getDate()}`;
+                    dateText = dateText.replace('今天', todayDateStr).replace('昨天', yesterdayDateStr);
+                }
+                item.timestamp = toUTCDate(dateText, 8);
+
+                // team
+                item.team = new Team();
+                const teamLink = $('td:nth-child(2) > a.magnet-link-wrap', tr);
+                const teamHref = teamLink.attr('href');
+                if (teamHref) {
+                    const teamMatch = teamHref.trim().match(/\/Home\/PublishGroup\/(\d+)/);
+                    if (teamMatch) {
+                        item.team.id = teamMatch[1];
+                    }
+                }
+                item.team.name = teamLink.length ? teamLink.text().trim() : null;
+
+                // publisher
+                item.publisher = new Publisher();
+                item.publisher.id = item.team.id;
+                item.publisher.name = item.team.name;
+
+                // title
+                const titleLink = $('td:nth-child(3) > a.magnet-link-wrap', tr);
+                item.title = titleLink.length ? titleLink.text().trim() : '';
+
+                // magnet
+                const magnetLink = $('td:nth-child(3) > a.js-magnet.magnet-link', tr);
+                item.magnet_uri = magnetLink.attr('data-clipboard-text')
+                    ? magnetLink.attr('data-clipboard-text').trim()
+                    : null;
+
+                // torrent
+                const torrentLink = $('td:nth-child(5) > a', tr);
+                const torrentHref = torrentLink.attr('href');
+                if (torrentHref) {
+                    const urlObj = new URL(torrentHref.trim(), MikananiMeLight._host);
+                    item.torrent_url = urlObj.toString();
+                } else {
+                    item.torrent_url = null;
+                }
+
+                item.id = items[i].id;
+                item.uri = items[i].uri;
+                newItems.push(item);
+            }
+            return { hasNext: newIds.length === items.length && newIds.length > 0, items: newItems };
+        } catch (e: any) {
+            await this.handleTimeout(e as unknown as Error);
+            logger.warn('execute_main_task_exception', {
+                code: e.code,
+                error_message: e.message,
+                line: '157',
+                page_no: pageNo,
+                stack: e.stack
+            });
+            return null;
+        }
+    }
+
+    public async executeSubTask(item: Item<string>): Promise<number> {
+        try {
+            logger.info('start to get torrent info for item#' + item.id);
+            const torrentPath = await downloadFile(item.torrent_url);
+            const info = await getTorrentInfo(torrentPath);
+            item.files = info.files;
+            // console.log(info.files);
+            await unlink(torrentPath);
+        } catch (e: any) {
+            let statusCode = -1;
+            if (e.response) {
+                statusCode = e.response.status;
+            }
+            if (statusCode === 404) {
+                // ignore 404 torrent url.
+                return 200;
+            }
+            await this.handleTimeout(e as unknown as Error);
+            logger.warn('execute_sub_task_exception', {
+                code: e.code,
+                error_message: e.message,
+                item,
+                line: '236',
+                stack: e.stack
+            });
+            return statusCode;
+        }
+        return 200;
+    }
+
+    private getIdFromUri(uri: string): string {
+        const match = uri.match(/\/Home\/Episode\/([a-f0-9]+)/);
+        if (match) {
+            return match[1];
+        }
+        return null;
+    }
+}

--- a/src/scraper/mikanani-me.ts
+++ b/src/scraper/mikanani-me.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { Browser, HTTPRequest, launch, Page } from 'puppeteer';
+import { Browser, HTTPRequest, launch, Page } from 'puppeteer-core';
 import { inject } from 'inversify';
 import { TaskOrchestra } from '../task/task-orchestra';
 import { Item } from '../entity/Item';
@@ -133,7 +133,7 @@ export class MikananiMe extends BaseScraper<string> {
             for (const tr of trList) {
                 const item = new Item<string>();
 
-                item.uri = await page.evaluate(el => {
+                item.uri = await page.evaluate((el: Element) => {
                     let titleLink = el.querySelector('td:nth-child(3)>a.magnet-link-wrap');
                     if (titleLink && titleLink.getAttribute('href')) {
                         return titleLink.getAttribute('href').trim();
@@ -156,7 +156,7 @@ export class MikananiMe extends BaseScraper<string> {
                 const tr = trList[i];
                 const item = new Item<string>();
                 // datetime
-                item.timestamp = toUTCDate(await page.evaluate(el => {
+                item.timestamp = toUTCDate(await page.evaluate((el: Element) => {
                     let dateTextTd = el.querySelector('td:first-child');
                     let dateText = '';
                     if (dateTextTd) {
@@ -174,7 +174,7 @@ export class MikananiMe extends BaseScraper<string> {
                 }, tr), 8);
 
                 item.team = new Team();
-                item.team.id = await page.evaluate((el) => {
+                item.team.id = await page.evaluate((el: Element) => {
                     const teamLink = el.querySelector('td:nth-child(2) > a.magnet-link-wrap');
                     if (teamLink && teamLink.getAttribute('href')) {
                         const teamLinkUri = teamLink.getAttribute('href').trim();
@@ -186,7 +186,7 @@ export class MikananiMe extends BaseScraper<string> {
                     return null;
                 }, tr);
 
-                item.team.name = await page.evaluate(el => {
+                item.team.name = await page.evaluate((el: Element) => {
                     const teamLink = el.querySelector('td:nth-child(2) > a.magnet-link-wrap');
                     if (teamLink) {
                         return teamLink.textContent.trim();
@@ -198,7 +198,7 @@ export class MikananiMe extends BaseScraper<string> {
                 item.publisher.id = item.team.id;
                 item.publisher.name = item.team.name;
 
-                item.title = await page.evaluate(el => {
+                item.title = await page.evaluate((el: Element) => {
                     let titleLink = el.querySelector('td:nth-child(3)>a.magnet-link-wrap');
                     if (titleLink) {
                         return titleLink.textContent.trim();
@@ -206,7 +206,7 @@ export class MikananiMe extends BaseScraper<string> {
                     return '';
                 }, tr);
 
-                item.magnet_uri = await page.evaluate(el => {
+                item.magnet_uri = await page.evaluate((el: Element) => {
                     let magnetLink = el.querySelector('td:nth-child(3) > a.js-magnet.magnet-link');
                     if (magnetLink && magnetLink.getAttribute('data-clipboard-text')) {
                         return magnetLink.getAttribute('data-clipboard-text').trim();
@@ -214,7 +214,7 @@ export class MikananiMe extends BaseScraper<string> {
                     return null;
                 }, tr);
 
-                item.torrent_url = await page.evaluate(el => {
+                item.torrent_url = await page.evaluate((el: Element) => {
                     let torrentLink = el.querySelector('td:nth-child(5) > a');
                     if (torrentLink && torrentLink.getAttribute('href')) {
                         return torrentLink.getAttribute('href').trim();

--- a/src/scraper/nyaa.ts
+++ b/src/scraper/nyaa.ts
@@ -123,7 +123,7 @@ export class NyaaScraper extends BaseScraper<number> {
             const torrentPath = await downloadFile(item.torrent_url);
             const info = await getTorrentInfo(torrentPath);
             item.files = info.files;
-            console.log(info.files);
+            // console.log(info.files);
             await unlink(torrentPath);
         } catch (e: any) {
             await this.handleTimeout(e as unknown as Error);

--- a/src/service/database-service.ts
+++ b/src/service/database-service.ts
@@ -19,12 +19,13 @@ import { CollectionInfo, Db, MongoClient } from 'mongodb';
 import { logger } from '../utils/logger-factory';
 import { Sentry, TYPES } from '@irohalab/mira-shared';
 import { ConfigManager } from '../utils/config-manager';
+import { TYPES_IDX } from '../TYPES_IDX';
+import { MongoClientProvider } from './mongo-client-provider';
 
 @injectable()
 export class DatabaseService {
 
     private _db: Db;
-    private _client: MongoClient;
     private _collectionNames: string[] = [];
 
     public get db(): Db {
@@ -32,19 +33,17 @@ export class DatabaseService {
     }
 
     constructor(@inject(TYPES.ConfigManager) private _config: ConfigManager,
-                @inject(TYPES.Sentry) private _sentry: Sentry) {
+                @inject(TYPES.Sentry) private _sentry: Sentry,
+                @inject(TYPES_IDX.DBName) private _dbName: string,
+                @inject(MongoClientProvider) private _clientProvider: MongoClientProvider) {
     }
 
     public async onEnd(): Promise<void> {
-        await this._client.close();
+        // MongoClient lifecycle is managed by MongoClientProvider
     }
 
     public async onStart(): Promise<void> {
-        const url = `mongodb://${this._config.getDbUser()}:${this._config.getDbPass()}@${
-            this._config.getDbHost()
-            }:${this._config.getDbPort()}?authSource=${this._config.getAuthSource()}`;
-        this._client = await MongoClient.connect(url);
-        this._db = this._client.db(this._config.getDbName());
+        this._db = this._clientProvider.client.db(this._dbName);
         await this._doCheckCollection();
         return Promise.resolve();
     }
@@ -61,10 +60,11 @@ export class DatabaseService {
 
     public async transaction(transactionAction: (client: MongoClient) => Promise<void>): Promise<void> {
         let session = null;
+        const client = this._clientProvider.client;
         try {
-            session = this._client.startSession();
+            session = client.startSession();
             await session.withTransaction(async () => {
-                await transactionAction(this._client);
+                await transactionAction(client);
             });
         } catch (e) {
             logger.error('transaction_error', {

--- a/src/service/mongo-client-provider.ts
+++ b/src/service/mongo-client-provider.ts
@@ -1,0 +1,52 @@
+/*
+ * Copyright 2026 IROHA LAB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { inject, injectable } from 'inversify';
+import { MongoClient } from 'mongodb';
+import { logger } from '../utils/logger-factory';
+import { TYPES } from '@irohalab/mira-shared';
+import { ConfigManager } from '../utils/config-manager';
+
+/**
+ * Shared MongoClient provider. Singleton in the root container.
+ * Each mode's DatabaseService gets its own Db instance from this shared client.
+ */
+@injectable()
+export class MongoClientProvider {
+
+    private _client!: MongoClient;
+
+    public get client(): MongoClient {
+        return this._client;
+    }
+
+    constructor(@inject(TYPES.ConfigManager) private _config: ConfigManager) {
+    }
+
+    public async connect(): Promise<void> {
+        const url = `mongodb://${this._config.getDbUser()}:${this._config.getDbPass()}@${
+            this._config.getDbHost()
+        }:${this._config.getDbPort()}?authSource=${this._config.getAuthSource()}`;
+        this._client = await MongoClient.connect(url);
+        logger.info('MongoClient connected');
+    }
+
+    public async close(): Promise<void> {
+        if (this._client) {
+            await this._client.close();
+        }
+    }
+}

--- a/src/storage/mongodb-item-store.spec.ts
+++ b/src/storage/mongodb-item-store.spec.ts
@@ -19,6 +19,7 @@ import { fail } from 'assert';
 import { Container } from 'inversify';
 import { MongoClient } from 'mongodb';
 import { DatabaseService } from '../service/database-service';
+import { MongoClientProvider } from '../service/mongo-client-provider';
 import { FakeConfigManager } from '../test/fake-config';
 import { items } from '../test/test-samples';
 import { ItemStorage, TYPES_IDX } from '../TYPES_IDX';
@@ -33,8 +34,11 @@ export class MongodbItemStoreSpec {
     private _config: ConfigManager;
     private _container: Container;
     private _databaseService: DatabaseService;
+    private _mongoClientProvider: MongoClientProvider;
 
     private _collectionName: string = 'items';
+    private static readonly TEST_MODE = 'test';
+    private dbName: string;
 
     @SetupFixture
     public setupFixture() {
@@ -43,28 +47,30 @@ export class MongodbItemStoreSpec {
         }
         this._container = new Container();
         this._container.bind<ConfigManager>(TYPES.ConfigManager).to(FakeConfigManager).inSingletonScope();
+        this._container.bind<MongoClientProvider>(MongoClientProvider).toSelf().inSingletonScope();
+        this._container.bind<string>(TYPES_IDX.DBName).toConstantValue(`${MongodbItemStoreSpec.TEST_MODE}_indexer`);
         this._container.bind<DatabaseService>(DatabaseService).toSelf().inSingletonScope();
         this._container.bind<ItemStorage<number>>(TYPES_IDX.ItemStorage).to(MongodbItemStore).inTransientScope();
         this._container.bind<Sentry>(TYPES.Sentry).to(FakeSentry).inSingletonScope();
         this._config = this._container.get<ConfigManager>(TYPES.ConfigManager);
-        this._config.prepare();
-        // this._config.dbHost = 'mongo';
+        this.dbName = this._container.get(TYPES_IDX.DBName);
         (this._config as FakeConfigManager).dbPort = 27017;
     }
 
     @Setup
     public async databaseInit(): Promise<void> {
-        // Cast to PostgresStore<number>
-        this._databaseService = await this._container.get<DatabaseService>(DatabaseService);
+        this._mongoClientProvider = this._container.get<MongoClientProvider>(MongoClientProvider);
+        await this._mongoClientProvider.connect();
+        this._databaseService = this._container.get<DatabaseService>(DatabaseService);
         await this._databaseService.onStart();
         this._store = this._container.get<ItemStorage<number>>(TYPES_IDX.ItemStorage) as MongodbItemStore<number>;
     }
 
     @Teardown
     public async databaseCleanUp(): Promise<void> {
-        await this._databaseService.onEnd();
         const client = await this._createClient();
-        await client.db(this._config.getDbName()).collection(this._collectionName).drop();
+        await client.db(this.dbName).collection(this._collectionName).drop();
+        await this._mongoClientProvider.close();
     }
 
     @TestCase(0)
@@ -75,7 +81,7 @@ export class MongodbItemStoreSpec {
         Expect(isSuccess).toBeTruthy();
         const client = await this._createClient();
         const result = await client
-        .db(this._config.getDbName())
+        .db(this.dbName)
         .collection(this._collectionName)
         .find({})
         .project({ _id: 0 })

--- a/src/storage/mongodb-task-store.spec.ts
+++ b/src/storage/mongodb-task-store.spec.ts
@@ -20,6 +20,7 @@ import { Container } from 'inversify';
 import { MongoClient } from 'mongodb';
 import { Item } from '../entity/Item';
 import { DatabaseService } from '../service/database-service';
+import { MongoClientProvider } from '../service/mongo-client-provider';
 import { SubTask } from '../task/sub-task';
 import { TaskType } from '../task/task-types';
 import { FakeConfigManager } from '../test/fake-config';
@@ -36,9 +37,12 @@ export class MongodbItemStoreSpec {
     private _config: ConfigManager;
     private _container: Container;
     private _databaseService: DatabaseService;
+    private _mongoClientProvider: MongoClientProvider;
 
     private _taskCollectionName = 'task';
     private _failedTaskCollectionName = 'failed_task';
+    private static readonly TEST_MODE = 'test';
+    private dbName: string;
 
     @SetupFixture
     public setupFixture() {
@@ -47,19 +51,21 @@ export class MongodbItemStoreSpec {
         }
         this._container = new Container();
         this._container.bind<ConfigManager>(TYPES.ConfigManager).to(FakeConfigManager).inSingletonScope();
+        this._container.bind<MongoClientProvider>(MongoClientProvider).toSelf().inSingletonScope();
+        this._container.bind<string>(TYPES_IDX.DBName).toConstantValue(`${MongodbItemStoreSpec.TEST_MODE}_indexer`);
         this._container.bind<DatabaseService>(DatabaseService).toSelf().inSingletonScope();
         this._container.bind<TaskQueue>(TYPES_IDX.TaskStorage).to(MongodbTaskStore).inTransientScope();
         this._container.bind<Sentry>(TYPES.Sentry).to(FakeSentry).inSingletonScope();
         this._config = this._container.get<ConfigManager>(TYPES.ConfigManager);
-        this._config.prepare();
-        // this._config.dbHost = 'mongo';
+        this.dbName = this._container.get<string>(TYPES_IDX.DBName);
         (this._config as FakeConfigManager).dbPort = 27017;
     }
 
     @Setup
     public async databaseInit(): Promise<void> {
-        // Cast to PostgresStore<number>
-        this._databaseService = await this._container.get<DatabaseService>(DatabaseService);
+        this._mongoClientProvider = this._container.get<MongoClientProvider>(MongoClientProvider);
+        await this._mongoClientProvider.connect();
+        this._databaseService = this._container.get<DatabaseService>(DatabaseService);
         await this._databaseService.onStart();
         this._store = this._container.get<TaskQueue>(TYPES_IDX.TaskStorage) as MongodbTaskStore;
     }
@@ -67,14 +73,14 @@ export class MongodbItemStoreSpec {
     @Teardown
     public async databaseCleanUp(): Promise<void> {
         const client = await this._createClient();
-        const cur = client.db(this._config.getDbName()).listCollections({}, {nameOnly: true});
+        const cur = client.db(this.dbName).listCollections({}, {nameOnly: true});
         const existCollections = await cur.toArray();
         if (existCollections) {
             for (let collectionName of existCollections) {
-                await client.db(this._config.getDbName()).collection(collectionName.name).drop();
+                await client.db(this.dbName).collection(collectionName.name).drop();
             }
         }
-        await this._databaseService.onEnd();
+        await this._mongoClientProvider.close();
     }
 
     @Test('Task Queue Operation')

--- a/src/storage/mongodb-task-store.ts
+++ b/src/storage/mongodb-task-store.ts
@@ -20,7 +20,7 @@ import { DatabaseService } from '../service/database-service';
 import { MainTask } from '../task/main-task';
 import { SubTask } from '../task/sub-task';
 import { Task, TaskType } from '../task/task-types';
-import { TaskQueue } from '../TYPES_IDX';
+import { TaskQueue, TYPES_IDX } from '../TYPES_IDX';
 import { TYPES } from '@irohalab/mira-shared';
 import { ConfigManager } from '../utils/config-manager';
 
@@ -35,6 +35,7 @@ export class MongodbTaskStore implements TaskQueue {
     private _failedTaskCollectionName = 'failed_task';
 
     constructor(private _databaseService: DatabaseService,
+                @inject(TYPES_IDX.DBName) private dbName: string,
                 @inject(TYPES.ConfigManager) private _config: ConfigManager) {
         this._databaseService.checkCollection([this._taskCollectionName, this._failedTaskCollectionName]);
     }
@@ -69,7 +70,7 @@ export class MongodbTaskStore implements TaskQueue {
 
     private async push(collection: string, task: Task): Promise<boolean> {
         await this._databaseService.transaction(async (client) => {
-            const taskCollection = client.db(this._config.getDbName()).collection(collection);
+            const taskCollection = client.db(this.dbName).collection(collection);
             let filterObj: any = {type: task.type};
             if (task.type === TaskType.MAIN) {
                 if (task instanceof MainTask) {

--- a/src/storage/mongodb-throttle-store.ts
+++ b/src/storage/mongodb-throttle-store.ts
@@ -68,4 +68,19 @@ export class MongodbThrottleStore implements ThrottleStore {
         await this.db.collection(this._throttleCollectionName).findOneAndUpdate({name},
             {$set: {timestamp: Date.now()}}, {upsert: true});
     }
+
+    /**
+     * Atomically check if enough time has passed and claim the slot.
+     * Returns true if this instance won the race, false if another instance already claimed it.
+     */
+    public async tryClaimTaskTime(name: string, minInterval: number): Promise<boolean> {
+        const threshold = Date.now() - minInterval;
+        const result = await this.db.collection(this._throttleCollectionName).findOneAndUpdate(
+            { name, $or: [{ timestamp: { $lte: threshold } }, { timestamp: { $exists: false } }] },
+            { $set: { timestamp: Date.now() } },
+            { upsert: true, returnDocument: 'after' }
+        );
+        // If the update matched and modified, this instance won the race
+        return result != null;
+    }
 }

--- a/src/task/scraper-coordinator.ts
+++ b/src/task/scraper-coordinator.ts
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2026 IROHA LAB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Scraper } from '../TYPES_IDX';
+import { logger } from '../utils/logger-factory';
+
+/**
+ * Coordinates multiple scrapers in a single process.
+ * Manages starting and stopping all mode-specific scrapers.
+ */
+export class ScraperCoordinator implements Scraper {
+    private _scrapers: { mode: string, scraper: Scraper }[] = [];
+
+    public addScraper(mode: string, scraper: Scraper): void {
+        this._scrapers.push({ mode, scraper });
+    }
+
+    public initMQ(): Promise<void> {
+        throw new Error('Method not implemented.');
+    }
+
+    public async start(): Promise<void> {
+        /* Phase 1: register all exchanges/queues with the broker config
+           before the broker is created (RascalImpl creates it on first consume) */
+        for (const { mode, scraper } of this._scrapers) {
+            logger.info('init_mq_for_scraper', { mode });
+            await scraper.initMQ();
+        }
+
+        /* Phase 2: now start consuming and task loops */
+        for (const { mode, scraper } of this._scrapers) {
+            logger.info('starting_scraper', { mode });
+            await scraper.start();
+        }
+        logger.info('all_scrapers_started', { count: this._scrapers.length });
+    }
+
+    public async end(): Promise<void> {
+        for (const { mode, scraper } of this._scrapers) {
+            logger.info('stopping_scraper', { mode });
+            await scraper.end();
+        }
+    }
+
+    public async executeTask(): Promise<any> {
+        throw new Error('ScraperCoordinator does not execute tasks directly');
+    }
+}

--- a/src/task/task-orchestra.spec.ts
+++ b/src/task/task-orchestra.spec.ts
@@ -42,11 +42,11 @@ export class TaskOrchestraSpec {
         this._container.bind<interfaces.Factory<number>>(TYPES_IDX.TaskTimingFactory).toFactory<number>(MockTaskTiming);
         this._container.bind<TaskQueue>(TYPES_IDX.TaskStorage).to(InMemoryTaskStore).inSingletonScope();
         this._container.bind<RabbitMQService>(TYPES.RabbitMQService).to(RascalImpl).inSingletonScope();
+        this._container.bind<string>(TYPES_IDX.Mode).toConstantValue('test');
         this._container.bind<TaskOrchestra>(TaskOrchestra).toSelf();
         this._container.bind<Scraper>(TYPES_IDX.Scraper).to(FakeScraper).inTransientScope();
         this._container.bind<ThrottleStore>(TYPES_IDX.ThrottleStore).to(InMemoryThrottleStore).inSingletonScope();
         this._config = this._container.get<ConfigManager>(TYPES.ConfigManager);
-        this._config.prepare();
         (this._config as unknown as FakeConfigManager).minCheckInterval = MIN_INTERVAL * 3;
         (this._config as unknown as FakeConfigManager).minInterval = MIN_INTERVAL;
         (this._config as unknown as FakeConfigManager).minFailedTaskCheckInterval = MIN_INTERVAL * 2;

--- a/src/task/task-orchestra.ts
+++ b/src/task/task-orchestra.ts
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-import { inject, injectable } from 'inversify';
+import { inject, injectable, optional } from 'inversify';
 import {
     Scraper,
     TASK_EXCHANGE,
@@ -31,6 +31,7 @@ import { MQMessage, RabbitMQService, TYPES } from '@irohalab/mira-shared';
 import { promisify } from 'util';
 import Timeout = NodeJS.Timeout;
 import { ConfigManager } from '../utils/config-manager';
+import { AsyncMutex } from '../utils/async-mutex';
 
 const sleep = promisify(setTimeout) as (t: number) => Promise<unknown>;
 
@@ -50,17 +51,30 @@ export class TaskOrchestra {
                 @inject(TYPES_IDX.TaskTimingFactory) private _taskTimingFactory: (interval: number) => number,
                 @inject(TYPES.RabbitMQService) private _mqService: RabbitMQService,
                 @inject(TYPES_IDX.TaskStorage) private _taskStore: TaskQueue,
-                @inject(TYPES_IDX.ThrottleStore) private _throttleStore: ThrottleStore) {
-        this._exchangeName = `${TASK_EXCHANGE}_${this._config.getMode()}`;
-        this._queueName = `${TASK_QUEUE}_${this._config.getMode()}`;
-        this._taskRoutingKey = `${TASK_ROUTING_KEY}_${this._config.getMode()}`;
+                @inject(TYPES_IDX.ThrottleStore) private _throttleStore: ThrottleStore,
+                @inject(TYPES_IDX.Mode) private mode: string,
+                @inject(TYPES_IDX.AsyncMutex) @optional() private _mutex: AsyncMutex | null) {
+        this._exchangeName = `${TASK_EXCHANGE}_${this.mode}`;
+        this._queueName = `${TASK_QUEUE}_${this.mode}`;
+        this._taskRoutingKey = `${TASK_ROUTING_KEY}_${this.mode}`;
+    }
+
+    /**
+     * Register exchanges, queues, and bindings with the message broker.
+     * Must be called on ALL orchestras before any of them calls start(),
+     * because RascalImpl creates the broker lazily on the first consume().
+     */
+    public async initMQ(): Promise<void> {
+        if (this._mutex) {
+            this._mutex.registerMode(this.mode);
+        }
+        await this._mqService.initPublisher(this._exchangeName, 'direct', this._taskRoutingKey);
+        await this._mqService.initConsumer(this._exchangeName, 'direct', this._queueName, this._taskRoutingKey);
     }
 
     public async start(scraper: Scraper): Promise<void> {
         let actualInterval = this._taskTimingFactory(this._config.getMinInterval());
         this._scraper = scraper;
-        await this._mqService.initPublisher(this._exchangeName, 'direct', this._taskRoutingKey);
-        await this._mqService.initConsumer(this._exchangeName, 'direct', this._queueName, this._taskRoutingKey);
         await this._mqService.consume(this._queueName, async (msg: MQMessage) => {
             const task = msg as Task;
             const currentTime = Date.now();
@@ -68,12 +82,19 @@ export class TaskOrchestra {
                 await sleep(2000);
                 return false;
             }
-            this._lastExeTime = Date.now();
-            let result = await this._scraper.executeTask(task);
-            if (result === TaskStatus.NeedRetry) {
-                await this._taskStore.offerFailedTask(task);
-            } else if (result === TaskStatus.Success && task.type === TaskType.MAIN) {
-                this._lastMainTaskExeTime = Date.now();
+            const executeTask = async () => {
+                this._lastExeTime = Date.now();
+                let result = await this._scraper.executeTask(task);
+                if (result === TaskStatus.NeedRetry) {
+                    await this._taskStore.offerFailedTask(task);
+                } else if (result === TaskStatus.Success && task.type === TaskType.MAIN) {
+                    this._lastMainTaskExeTime = Date.now();
+                }
+            };
+            if (this._mutex) {
+                await this._mutex.runExclusive(this.mode, executeTask);
+            } else {
+                await executeTask();
             }
             return true;
         });
@@ -91,13 +112,20 @@ export class TaskOrchestra {
     }
 
     private async checkMainTask(actualInterval: number): Promise<void> {
-        const lastMainTaskTime = await this._throttleStore.getLastMainTaskTime();
         const currentTime = Date.now();
-        const delta = currentTime - lastMainTaskTime;
-        if (delta >= this._config.getMinCheckInterval() && currentTime >= this._lastExeTime + actualInterval) {
-            this._lastExeTime = currentTime;
-            await this._throttleStore.setLastMainTaskTime();
-            await this._scraper.executeTask(new CommonTask(TaskType.MAIN));
+        if (currentTime >= this._lastExeTime + actualInterval) {
+            const claimed = await this._throttleStore.tryClaimTaskTime('MainTask', this._config.getMinCheckInterval());
+            if (claimed) {
+                const executeMainTask = async () => {
+                    this._lastExeTime = Date.now();
+                    await this._scraper.executeTask(new CommonTask(TaskType.MAIN));
+                };
+                if (this._mutex) {
+                    await this._mutex.runExclusive(this.mode, executeMainTask);
+                } else {
+                    await executeMainTask();
+                }
+            }
         }
         this._checkMainTaskTimerId = setTimeout(() => {
             this.checkMainTask(actualInterval).catch((err) => {
@@ -107,11 +135,8 @@ export class TaskOrchestra {
     }
 
     private async checkFailedTask(): Promise<void> {
-        const lastFailedTaskTime = await this._throttleStore.getLastFailedTaskTime();
-        const currentTime = Date.now();
-        const delta = currentTime - lastFailedTaskTime;
-        if (delta >= this._config.getMinFailedTaskCheckInterval()) {
-            await this._throttleStore.setLastFailedTaskTime();
+        const claimed = await this._throttleStore.tryClaimTaskTime('FailedTask', this._config.getMinFailedTaskCheckInterval());
+        if (claimed) {
             while (await this.pickFailedTask()) {
                 await sleep(1000); // some small interval to queue task.
             }
@@ -122,68 +147,6 @@ export class TaskOrchestra {
                 logger.error('check_failed_task_error', { message: err.message, stack: err.stack });
             });
         }, checkInterval);
-    }
-
-    private pick(): void {
-        let actualInterval = this._taskTimingFactory(this._config.getMinInterval());
-        this.pickTask()
-            .then((hasTask) => {
-                /* if task queue is empty, try failed task */
-                if (!hasTask) {
-                    return this.pickFailedTask();
-                }
-                return true;
-            })
-            .then((hasSomeTaskExecuted) => {
-                /* Need to ensure the list page is checked regularly */
-                if (Date.now() - this._lastMainTaskExeTime > this._config.getMinCheckInterval()) {
-                    // force queue a MainTask
-                    logger.info('force_queue', {
-                        last_main_task_execute_time: this._lastMainTaskExeTime,
-                        min_check_interval: this._config.getMinCheckInterval()
-                    });
-                    this.queue(new CommonTask(TaskType.MAIN))
-                        .then(() => {
-                            this._checkMainTaskTimerId = setTimeout(() => {
-                                this.pick();
-                            }, actualInterval);
-                        });
-                    return;
-                }
-                /* Either task or failed task has been executed, we will try to pick again */
-                if (hasSomeTaskExecuted) {
-                    this._checkMainTaskTimerId = setTimeout(() => {
-                        this.pick();
-                    }, actualInterval);
-                } else {
-                    logger.info('no task in queue, queue a main task');
-                    this.queue(new CommonTask(TaskType.MAIN))
-                        .then(() => {
-                            let offset = Date.now() - this._lastMainTaskExeTime;
-                            this._checkMainTaskTimerId = setTimeout(() => {
-                                this.pick();
-                            }, Math.max(this._config.getMinCheckInterval() - offset, actualInterval));
-                        });
-                }
-            });
-    }
-
-    /**
-     * Pick a task from task queue
-     * @returns {Promise<boolean>} true if a task is picked, false if the task queue is empty.
-     */
-    private async pickTask(): Promise<boolean> {
-        if (await this._taskStore.hasTask()) {
-            let task = await this._taskStore.pollTask();
-            let result = await this._scraper.executeTask(task);
-            if (result === TaskStatus.NeedRetry) {
-                await this._taskStore.offerFailedTask(task);
-            } else if (result === TaskStatus.Success && task.type === TaskType.MAIN) {
-                this._lastMainTaskExeTime = Date.now();
-            }
-            return true;
-        }
-        return false;
     }
 
     /**

--- a/src/test/fake-config.ts
+++ b/src/test/fake-config.ts
@@ -33,8 +33,12 @@ export class FakeConfigManager implements ConfigManager {
     getMinFailedTaskCheckInterval(): number {
        return this.minFailedTaskCheckInterval || parseInt(process.env.MIN_FAILED_TASK_CHECK_INTERVAL, 10) || (60 * 1000);
     }
-    getMode(): string {
-        return process.env.INDEXER_MODE;
+    getModeList(): string[] {
+        const listStr = process.env.MODE_LIST;
+        if (listStr) {
+            return listStr.split(',');
+        }
+        return [process.env.INDEXER_MODE || 'dmhy'];
     }
     getDbMode(): string {
         return process.env.DB_MODE || 'mongo';
@@ -48,11 +52,11 @@ export class FakeConfigManager implements ConfigManager {
     getDbUser(): string {
         return process.env.DB_USER || process.env.USER;
     }
-    getDbName(): string {
+    getDbName(mode?: string): string {
         if (process.env.DB_NAME) {
             return process.env.DB_NAME;
         } else {
-            return this.getMode() + '_indexer';
+            return (mode || 'test') + '_indexer';
         }
     }
     getDbPass(): string {
@@ -83,9 +87,7 @@ export class FakeConfigManager implements ConfigManager {
         return parseInt(process.env.MAX_RETRY_COUNT, 10) || 5;
     }
     prepare(): void {
-        if (!this.getMode()) {
-            throw new Error('No mode specified!');
-        }
+        // no-op for tests
     }
     amqpConfig(): Options.Connect {
         return {

--- a/src/test/fake-scraper.ts
+++ b/src/test/fake-scraper.ts
@@ -49,6 +49,10 @@ export class FakeScraper implements Scraper {
         return Promise.resolve(null);
     }
 
+    public async initMQ(): Promise<void> {
+        await this._taskOrchestra.initMQ();
+    }
+
     public async executeTask(task: Task): Promise<TaskStatus> {
         if (task.type === TaskType.SUB) {
             return await this.doExecuteSubTask(task as FakeTask);

--- a/src/test/in-memory-throttle-store.ts
+++ b/src/test/in-memory-throttle-store.ts
@@ -42,4 +42,14 @@ export class InMemoryThrottleStore implements ThrottleStore {
         return Promise.resolve();
     }
 
+    tryClaimTaskTime(name: string, minInterval: number): Promise<boolean> {
+        const key = name === 'MainTask' ? 'main' : 'failed';
+        const last = this.tasks[key];
+        if (Date.now() - last >= minInterval) {
+            this.tasks[key] = Date.now();
+            return Promise.resolve(true);
+        }
+        return Promise.resolve(false);
+    }
+
 }

--- a/src/utils/async-mutex.ts
+++ b/src/utils/async-mutex.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright 2026 IROHA LAB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { injectable } from 'inversify';
+
+/**
+ * A round-robin mutex that ensures fair scheduling across modes.
+ * When multiple modes have tasks waiting, they are served in round-robin order
+ * instead of FIFO, preventing any single mode from starving others.
+ */
+@injectable()
+export class AsyncMutex {
+    private _modeQueues: Map<string, (() => void)[]> = new Map();
+    private _modeOrder: string[] = [];
+    private _currentIndex = 0;
+    private _locked = false;
+
+    /**
+     * Register a mode for round-robin scheduling.
+     * Must be called before acquire/runExclusive for that mode.
+     */
+    public registerMode(mode: string): void {
+        if (!this._modeQueues.has(mode)) {
+            this._modeQueues.set(mode, []);
+            this._modeOrder.push(mode);
+        }
+    }
+
+    public async acquire(mode: string): Promise<void> {
+        if (!this._locked) {
+            this._locked = true;
+            return;
+        }
+        return new Promise<void>((resolve) => {
+            this._modeQueues.get(mode)!.push(resolve);
+        });
+    }
+
+    public release(): void {
+        // Round-robin: scan from current index to find next mode with waiting tasks
+        const len = this._modeOrder.length;
+        for (let i = 0; i < len; i++) {
+            const idx = (this._currentIndex + i) % len;
+            const mode = this._modeOrder[idx];
+            const queue = this._modeQueues.get(mode)!;
+            if (queue.length > 0) {
+                this._currentIndex = (idx + 1) % len;
+                const next = queue.shift()!;
+                next();
+                return;
+            }
+        }
+        this._locked = false;
+    }
+
+    /**
+     * Execute a function while holding the mutex lock.
+     * Tasks are scheduled in round-robin order across modes.
+     */
+    public async runExclusive<T>(mode: string, fn: () => Promise<T>): Promise<T> {
+        await this.acquire(mode);
+        try {
+            return await fn();
+        } finally {
+            this.release();
+        }
+    }
+}

--- a/src/utils/config-manager-impl.ts
+++ b/src/utils/config-manager-impl.ts
@@ -17,20 +17,31 @@
 import { MikroORMOptions } from '@mikro-orm/core';
 import { SqlEntityManager } from '@mikro-orm/knex';
 import { PostgreSqlDriver } from '@mikro-orm/postgresql';
-import { ConfigManager } from './config-manager';
+import { ACG_RIP, BANGUMI_MOE, ConfigManager, DMHY, MIKANANI_ME, NYAA } from './config-manager';
 import { injectable } from 'inversify';
 import { Options } from 'amqplib';
 import * as process from 'node:process';
 
+export const DEFAULT_MODE_LIST = [DMHY, ACG_RIP, NYAA, MIKANANI_ME, BANGUMI_MOE];
+
 @injectable()
 export class ConfigManagerImpl implements ConfigManager {
-    prepare(): void {
-        if (!this.getMode()) {
-            throw new Error('No mode specified!');
+    getModeList(): string[] {
+        const listStr = process.env.MODE_LIST; // a comma separated mode list
+        if (!listStr) {
+            return DEFAULT_MODE_LIST;
         }
-    }
-    getMode(): string {
-        return process.env.INDEXER_MODE;
+        const modeList = listStr.split(',');
+        if (modeList.length === 0) {
+            return DEFAULT_MODE_LIST;
+        }
+        const result = [];
+        for (const mode of modeList) {
+            if (DEFAULT_MODE_LIST.includes(mode)) {
+                result.push(mode);
+            }
+        }
+        return result;
     }
     getDbMode(): string {
         return process.env.DB_MODE || 'mongo';
@@ -43,13 +54,6 @@ export class ConfigManagerImpl implements ConfigManager {
     }
     getDbUser(): string {
         return process.env.DB_USER || process.env.USER;
-    }
-    getDbName(): string {
-        if (process.env.DB_NAME) {
-            return process.env.DB_NAME;
-        } else {
-            return this.getMode() + '_indexer';
-        }
     }
     getDbPass(): string {
         return process.env.DB_PASS || '123456';

--- a/src/utils/config-manager.ts
+++ b/src/utils/config-manager.ts
@@ -23,12 +23,11 @@ export const ACG_RIP = 'acg_rip';
 export const MIKANANI_ME = 'mikanani_me';
 
 export interface ConfigManager extends BaseConfigManager {
-    getMode(): string;
+    getModeList(): string[];
     getDbMode(): string;
     getDbHost(): string;
     getDbPort(): number;
     getDbUser(): string;
-    getDbName(): string;
     getDbPass(): string;
     getAuthSource(): string; // see: https://docs.mongodb.com/manual/core/security-users/#user-authentication-database
     getServerHost(): string;
@@ -39,6 +38,4 @@ export interface ConfigManager extends BaseConfigManager {
     getMaxPageNo(): number; // max page number for scrapping
     getMaxSearchCount(): number; // max search result count
     getMaxRetryCount(): number; // max retry times for a task
-
-    prepare(): void;
 }


### PR DESCRIPTION
# Merge scrapers into a unified process
## Problem
Each scraper mode (dmhy, bangumi_moe, nyaa, acg_rip, mikanani_me) ran as a separate Node.js process in production, each with its own MongoDB connection pool, RabbitMQ connection, and Puppeteer/Chromium instance. This caused high memory consumption across 5 containers.

## Solution
Merge all scraper modes into a single process with shared infrastructure and fair scheduling.

## Changes
New files:

async-mutex.ts — Round-robin mutex that fairly schedules task execution across modes (prevents any single scraper from starving others)
mongo-client-provider.ts — Shared MongoClient singleton (single connection pool for all modes)
scraper-coordinator.ts — Manages lifecycle of all scrapers with two-phase startup (init MQ config, then start consumers)
DI container architecture (main.ts):

Root container holds shared singletons: MongoClientProvider, RabbitMQService, AsyncMutex, ConfigManager, Sentry
Per-mode child containers hold mode-specific services: DatabaseService, TaskQueue, ThrottleStore, EventLogStore, ItemStorage, Scraper, TaskOrchestra
This fixes the original child container cache bug where parent-scoped singletons (e.g. DatabaseService) were resolved once and shared across all modes with the wrong database
RabbitMQ two-phase startup (task-orchestra.ts, base-scraper.ts):

Split TaskOrchestra.start() into initMQ() (registers exchanges/queues) and start() (consumes)
All modes register their MQ config before any broker is created, because RascalImpl creates the broker lazily on the first consume() call
Added initMQ() to the Scraper interface
Fair round-robin scheduling (async-mutex.ts, task-orchestra.ts):

AsyncMutex maintains a per-mode wait queue and cycles through modes when releasing the lock
Prevents a scraper with many sub-tasks (e.g. dmhy) from monopolizing execution while others starve
Atomic distributed throttling (mongodb-throttle-store.ts):

Added tryClaimTaskTime() — atomic findOneAndUpdate with a threshold filter
checkMainTask() and checkFailedTask() now use this instead of the non-atomic read-then-write pattern
Prevents duplicate main task execution when multiple instances share the same MongoDB
REST API multi-mode routing (items-query.ts):

Route changed from /item?keyword= to /:mode/item?keyword=
Controller injects a Map<string, ItemStorage> keyed by mode, replacing the single ItemStorage injection
Eliminates the need for Nginx URL rewriting per mode
Docker Compose:

docker-compose.prod.yml: 5 separate service containers → single indexer service with MODE_LIST env var
docker-compose.yml: replaced INDEXER_MODE/DB_NAME with MODE_LIST
Tests & mocks:

FakeConfigManager: added getModeList(), updated getDbName(mode) signature
mongodb-item-store.spec.ts, mongodb-task-store.spec.ts: added MongoClientProvider and DBName bindings
task-orchestra.spec.ts: added Mode binding
in-memory-throttle-store.ts: added tryClaimTaskTime()
fake-scraper.ts: added initMQ()
Multi-instance deployment
Works correctly when each instance runs non-overlapping modes via MODE_LIST. Shared MongoDB throttle store coordinates main task scheduling across instances atomically.

# Make a lightweight MikananiMeLight to replace MikananiMe
## Problem
MikananiMe uses Puppeteer to scrape mikanani.me, which will spin up a Chrome browser instance that eats quite a lot of memory.
Although mikanani.me is behind Cloudflare CDN, it doesn't prevent scraping.

## Solution
Use Axios + Cheerio to replace Puppeteer.

## Change
A new implementation: MikananiMeLight,
Replace bind with MikananiMeLight in main.ts
Replace puppeteer with puppeteer-core in package.json dependencies.
