### PR TITLE
Limit torrent file size

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "indexer",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "scripts": {
     "clean:dist": "rimraf dist/*",
     "build": "npm run clean:dist && tsc && cp package.json dist",

--- a/src/utils/torrent-utils.ts
+++ b/src/utils/torrent-utils.ts
@@ -14,12 +14,18 @@
  * limitations under the License.
  */
 
-import { readFile } from 'fs';
+import { readFile, stat } from 'fs';
 import { basename, extname } from 'path';
 import { promisify } from 'util';
 import { MediaFile } from '../entity/media-file';
 
 const readFilePromise = promisify(readFile);
+const statPromise = promisify(stat);
+
+// Torrent files larger than this are skipped to avoid OOM.
+// A typical anime series (several hundred episodes) produces a .torrent well under 1 MB.
+// The 262K-file torrent that caused OOM was 23 MB.
+const MAX_TORRENT_FILE_SIZE = 2 * 1024 * 1024; // 2 MB
 
 // Use indirect import to bypass ts-node converting import() to require(),
 // which fails because parse-torrent v11 is ESM-only.
@@ -38,6 +44,11 @@ export async function getTorrentFiles(torrentPath: string) {
 }
 
 export async function getTorrentInfo(torrentPath: string, withMagnet?: boolean) {
+    const fileInfo = await statPromise(torrentPath);
+    if (fileInfo.size > MAX_TORRENT_FILE_SIZE) {
+        return { magnet_uri: undefined, files: [] as MediaFile[] };
+    }
+
     const { parseTorrent, toMagnetURI } = await loadParseTorrent();
     const torrent = await readFilePromise(torrentPath);
     const parsed = await parseTorrent(torrent);


### PR DESCRIPTION
This pull request introduces a safeguard to prevent out-of-memory (OOM) errors when processing unusually large `.torrent` files. The main change is the addition of a file size check in the `getTorrentInfo` function, which now skips parsing torrent files larger than 2 MB. This helps ensure stability when handling edge cases with very large torrents.

Torrent file size limit and OOM prevention:

* Added a constant `MAX_TORRENT_FILE_SIZE` (2 MB) in `torrent-utils.ts`, and updated the `getTorrentInfo` function to check the file size using `stat`. Torrent files exceeding this size are skipped, returning empty results to prevent OOM errors. [[1]](diffhunk://#diff-26d3befbbaef53002dbc1cfe3ada77df688d48364f5fb3c4f4d4943f4777556fL17-R28) [[2]](diffhunk://#diff-26d3befbbaef53002dbc1cfe3ada77df688d48364f5fb3c4f4d4943f4777556fR47-R51)

Other changes:

* Updated the project version from `2.0.1` to `2.0.2` in `package.json` to reflect this fix.