### PR TITLE
Refactor task orchestrator: split main/sub queues, fix item loss & duplication, add multi-arch images (v3.0.0)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,6 +9,9 @@ jobs:
 
   release-package:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
     - uses: actions/checkout@v4
       with:
@@ -24,15 +27,38 @@ jobs:
         sentry-cli releases new $VERSION
         sentry-cli releases set-commits --auto $VERSION
 
-    - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@v5
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Log in to GitHub Container Registry
+      uses: docker/login-action@v3
       with:
-        name: irohalab/mira-resource-indexer/indexer
-        username: ${{ secrets.USERNAME }}
+        registry: ghcr.io
+        username: ${{ github.actor }}
         password: ${{ secrets.GITHUB_TOKEN }}
-        buildoptions: "--target prod"
-        registry: docker.pkg.github.com
-        tag_names: true
+
+    - name: Extract image metadata
+      id: meta
+      uses: docker/metadata-action@v5
+      with:
+        images: ghcr.io/irohalab/mira-resource-indexer/indexer
+        tags: |
+          type=ref,event=tag
+
+    - name: Build and push multi-arch image
+      uses: docker/build-push-action@v6
+      with:
+        context: .
+        target: prod
+        platforms: linux/amd64,linux/arm64
+        push: true
+        tags: ${{ steps.meta.outputs.tags }}
+        labels: ${{ steps.meta.outputs.labels }}
+        cache-from: type=gha
+        cache-to: type=gha,mode=max
 
     - name: Finalize release
       run: |

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "indexer",
-  "version": "2.1.0",
+  "version": "3.0.0",
   "scripts": {
     "clean:dist": "rimraf dist/*",
     "build": "npm run clean:dist && tsc && cp package.json dist",

--- a/src/TYPES_IDX.ts
+++ b/src/TYPES_IDX.ts
@@ -29,7 +29,8 @@ export const TYPES_IDX = {
     EventLogStore: Symbol.for('EventLogStore'),
     Mode: Symbol.for('Mode'),
     DBName: Symbol.for('DBName'),
-    AsyncMutex: Symbol.for('AsyncMutex'),
+    MainTaskMutex: Symbol.for('MainTaskMutex'),
+    SubTaskMutex: Symbol.for('SubTaskMutex'),
     MQControlAPIClient: Symbol.for('MQControlAPIClient'),
     SiteHealthMonitor: Symbol.for('SiteHealthMonitor')
 };
@@ -60,6 +61,7 @@ export interface ItemStorage<T> {
     getItem(id: T): Promise<Item<T>|null>;
     hasItem(id: T): Promise<boolean>;
     filterItemNotStored(ids: T[]): Promise<T[]>;
+    reserveItem(item: Item<T>): Promise<boolean>;
     putItem(item: Item<T>): Promise<boolean>;
     searchItem(keyword: string): Promise<Item<T>[]>;
 }
@@ -74,10 +76,6 @@ export interface TaskQueue {
 }
 
 export interface ThrottleStore {
-    getLastMainTaskTime(): Promise<number>;
-    setLastMainTaskTime(): Promise<void>;
-    getLastFailedTaskTime(): Promise<number>
-    setLastFailedTaskTime(): Promise<void>;
     tryClaimTaskTime(name: string, minInterval: number): Promise<boolean>;
 }
 
@@ -105,6 +103,13 @@ export interface Scraper {
      * @returns {Promise<boolean>} true, the
      */
     executeTask(task: Task): Promise<TaskStatus>;
+
+    /**
+     * Called when a task is permanently dropped (retries exhausted), so the scraper can
+     * release any reservation it made for the task (e.g. delete the reserved item stub) and
+     * allow the item to be rediscovered later.
+     */
+    handleDroppedTask?(task: Task): Promise<void>;
 }
 
 export const TASK_EXCHANGE = 'task_exchange';

--- a/src/main.ts
+++ b/src/main.ts
@@ -68,8 +68,9 @@ container.bind<RabbitMQService>(TYPES.RabbitMQService).to(RascalImpl).inSingleto
 /* Shared task timing factory */
 container.bind<interfaces.Factory<number>>(TYPES_IDX.TaskTimingFactory).toFactory<number>(TaskTiming);
 
-/* Shared AsyncMutex: ensures only one scraper task runs at a time */
-container.bind<AsyncMutex>(TYPES_IDX.AsyncMutex).to(AsyncMutex).inSingletonScope();
+/* Shared AsyncMutex lanes: at most one main task and one sub task run at a time across all modes */
+container.bind<AsyncMutex>(TYPES_IDX.MainTaskMutex).to(AsyncMutex).inSingletonScope();
+container.bind<AsyncMutex>(TYPES_IDX.SubTaskMutex).to(AsyncMutex).inSingletonScope();
 
 /* MQ management API client for queue depth checks */
 if (config.getAmqpServerType() === AMQPServerType.LavinMQ) {

--- a/src/scraper/abstract/base-scraper.ts
+++ b/src/scraper/abstract/base-scraper.ts
@@ -57,7 +57,10 @@ export abstract class BaseScraper<T> implements Scraper {
             }
             this._siteHealthMonitor.reportSuccess();
             for (let item of result.items) {
-                await this._taskOrchestra.queue(new SubTask<T>(TaskType.SUB, item));
+                const reserved = await this._store.reserveItem(item);
+                if (reserved) {
+                    await this._taskOrchestra.queue(new SubTask<T>(TaskType.SUB, item));
+                }
             }
             if (result.hasNext && (task as unknown as MainTask).pageNo < this._config.getMaxPageNo()) {
                 let newTask = new MainTask(TaskType.MAIN);
@@ -86,6 +89,19 @@ export abstract class BaseScraper<T> implements Scraper {
 
     public async initMQ(): Promise<void> {
         await this._taskOrchestra.initMQ();
+    }
+
+    /**
+     * Release the reservation for a permanently-dropped sub task so the item can be
+     * rediscovered by a later main task instead of being stuck as an incomplete stub.
+     */
+    public async handleDroppedTask(task: Task): Promise<void> {
+        if (task.type === TaskType.SUB) {
+            const item = (task as SubTask<T>).item;
+            if (item) {
+                await this._store.deleteItem(item.id);
+            }
+        }
     }
 
     public async start(): Promise<any> {

--- a/src/storage/mongodb-item-store.spec.ts
+++ b/src/storage/mongodb-item-store.spec.ts
@@ -105,6 +105,81 @@ export class MongodbItemStoreSpec {
         });
     }
 
+    @TestCase(0)
+    @Test('reserveItem should reserve once and dedupe subsequent reservations')
+    public async reserveItemDedup(index: number): Promise<void> {
+        const first = await this._store.reserveItem(Object.assign({}, items[index]));
+        Expect(first).toBe(true);
+        const second = await this._store.reserveItem(Object.assign({}, items[index]));
+        Expect(second).toBe(false);
+        const client = await this._createClient();
+        try {
+            const docs = await client.db(this.dbName).collection(this._collectionName)
+                .find({ id: items[index].id }).toArray();
+            Expect(docs.length).toBe(1);
+            Expect(docs[0].complete).toBe(false);
+        } finally {
+            await client.close();
+        }
+    }
+
+    @TestCase(0)
+    @Test('reserved (incomplete) item should be hidden from filterItemNotStored and searchItem')
+    public async reservedItemHidden(index: number): Promise<void> {
+        await this._store.reserveItem(Object.assign({}, items[index]));
+        const notStored = await this._store.filterItemNotStored([items[index].id]);
+        Expect(notStored.length).toBe(0);
+        const searchResult = await this._store.searchItem(items[index].title);
+        Expect(searchResult.length).toBe(0);
+    }
+
+    @TestCase(0)
+    @Test('putItem after reserveItem should complete the same document without duplicating')
+    public async putItemCompletesReservation(index: number): Promise<void> {
+        await this._store.reserveItem(Object.assign({}, items[index]));
+        const isSuccess = await this._store.putItem(Object.assign({}, items[index]));
+        Expect(isSuccess).toBeTruthy();
+        const client = await this._createClient();
+        try {
+            const docs = await client.db(this.dbName).collection(this._collectionName)
+                .find({ id: items[index].id }).toArray();
+            Expect(docs.length).toBe(1);
+            Expect(docs[0].complete).toBe(true);
+            Expect(docs[0].title).toBe(items[index].title);
+        } finally {
+            await client.close();
+        }
+        const searchResult = await this._store.searchItem(items[index].title);
+        Expect(searchResult.length).toBe(1);
+    }
+
+    @TestCase(0)
+    @Test('putItem should be idempotent for the same id (no duplicate documents)')
+    public async putItemIdempotent(index: number): Promise<void> {
+        await this._store.putItem(Object.assign({}, items[index]));
+        await this._store.putItem(Object.assign({}, items[index]));
+        const client = await this._createClient();
+        try {
+            const docs = await client.db(this.dbName).collection(this._collectionName)
+                .find({ id: items[index].id }).toArray();
+            Expect(docs.length).toBe(1);
+        } finally {
+            await client.close();
+        }
+    }
+
+    @TestCase(0)
+    @Test('deleteItem should release the reservation so the item can be rediscovered')
+    public async deleteItemReleasesReservation(index: number): Promise<void> {
+        await this._store.reserveItem(Object.assign({}, items[index]));
+        const deleted = await this._store.deleteItem(items[index].id);
+        Expect(deleted).toBe(true);
+        const notStored = await this._store.filterItemNotStored([items[index].id]);
+        Expect(notStored.length).toBe(1);
+        const reAcquired = await this._store.reserveItem(Object.assign({}, items[index]));
+        Expect(reAcquired).toBe(true);
+    }
+
     private async _createClient(): Promise<MongoClient> {
         const url = `mongodb://${this._config.getDbUser()}:${this._config.getDbPass()}@${
             this._config.getDbHost()

--- a/src/storage/mongodb-item-store.ts
+++ b/src/storage/mongodb-item-store.ts
@@ -15,7 +15,7 @@
  */
 
 import { inject, injectable } from 'inversify';
-import { Db } from 'mongodb';
+import { Collection, Db, ObjectId } from 'mongodb';
 import { Item } from '../entity/Item';
 import { DatabaseService } from '../service/database-service';
 import { ItemStorage } from '../TYPES_IDX';
@@ -31,14 +31,16 @@ export class MongodbItemStore<T> implements ItemStorage<T> {
     }
 
     private _collectionName: string = 'items';
+    private _indexReady: Promise<void> | null = null;
 
     constructor(@inject(TYPES.ConfigManager) private _config: ConfigManager,
                 private _databaseService: DatabaseService) {
         this._databaseService.checkCollection([this._collectionName]);
     }
 
-    public deleteItem(id: T): Promise<boolean> {
-        return undefined;
+    public async deleteItem(id: T): Promise<boolean> {
+        const result = await this.db.collection(this._collectionName).deleteMany({ id });
+        return result.deletedCount > 0;
     }
 
     public getItem(id: T): Promise<Item<T> | null> {
@@ -60,9 +62,50 @@ export class MongodbItemStore<T> implements ItemStorage<T> {
         return notStored;
     }
 
+    /**
+     * Atomically reserve an item at discovery time before a sub task is queued for it.
+     * Inserts a stub record (complete: false) keyed by the business `id`. Returns true only if
+     * this call created the reservation, so a concurrent or later main task that rediscovers
+     * the same item will NOT queue a duplicate sub task. The unique index on `id` makes the
+     * upsert race-safe (a losing concurrent insert throws E11000, which we treat as "already
+     * reserved").
+     */
+    public async reserveItem(item: Item<T>): Promise<boolean> {
+        await this.ensureUniqueIndex();
+        const payload: any = Object.assign({}, item);
+        delete payload._id;
+        delete payload.id;
+        try {
+            const result = await this.db.collection(this._collectionName).updateOne(
+                { id: item.id },
+                { $setOnInsert: Object.assign(payload, { complete: false }) },
+                { upsert: true }
+            );
+            return result.upsertedCount === 1;
+        } catch (e: any) {
+            if (e && (e.code === 11000 || e.codeName === 'DuplicateKey')) {
+                return false;
+            }
+            throw e;
+        }
+    }
+
+    /**
+     * Store the fully-scraped item, filling in the reservation stub and marking it complete.
+     * Upserts (rather than inserts) so it is idempotent and works even if the reservation is
+     * missing.
+     */
     public async putItem(item: Item<T>): Promise<boolean> {
-        await this.db.collection(this._collectionName).insertOne(Object.assign({}, item));
-        return Promise.resolve(true);
+        await this.ensureUniqueIndex();
+        const payload: any = Object.assign({}, item);
+        delete payload._id;
+        delete payload.id;
+        await this.db.collection(this._collectionName).updateOne(
+            { id: item.id },
+            { $set: Object.assign(payload, { complete: true }) },
+            { upsert: true }
+        );
+        return true;
     }
 
     public searchItem(keyword: string): Promise<Item<T>[]> {
@@ -75,8 +118,65 @@ export class MongodbItemStore<T> implements ItemStorage<T> {
             title: {
                 $options: 'i',
                 $regex: rgx
-            }
+            },
+            $or: [{ complete: true }, { complete: { $exists: false } }]
         }).sort({ timestamp: -1 }).limit(this._config.getMaxSearchCount());
         return Promise.resolve(cursor.toArray());
+    }
+
+    /**
+     * Ensure the unique index on `id` exists, running the one-time setup at most once per
+     * process. Memoized; the memo is cleared on failure so a later call can retry.
+     */
+    private ensureUniqueIndex(): Promise<void> {
+        if (!this._indexReady) {
+            this._indexReady = this.doEnsureUniqueIndex().catch((e) => {
+                this._indexReady = null;
+                throw e;
+            });
+        }
+        return this._indexReady;
+    }
+
+    /**
+     * Create the unique index on `id`. If legacy duplicate item documents (from the previous
+     * insertOne-based putItem) block it, collapse them with a delete-only pass and retry. Once
+     * the index exists it is enforced server-side, preventing any further duplicates.
+     */
+    private async doEnsureUniqueIndex(): Promise<void> {
+        const collection = this.db.collection<Item<T>>(this._collectionName);
+        const maxAttempts = 5;
+        for (let attempt = 0; attempt < maxAttempts; attempt++) {
+            try {
+                await collection.createIndex({ id: 1 }, { unique: true });
+                return;
+            } catch (e: any) {
+                if (!(e && (e.code === 11000 || e.codeName === 'DuplicateKey'))) {
+                    throw e;
+                }
+                await this.removeDuplicateItems(collection);
+            }
+        }
+        await collection.createIndex({ id: 1 }, { unique: true });
+    }
+
+    /**
+     * Delete-only de-duplication: for every business `id` with more than one document, keep the
+     * most complete / newest one (complete desc, then timestamp desc, ties broken by _id for a
+     * deterministic choice) and delete the rest by their specific _id. Never inserts, so it is
+     * idempotent and safe to run repeatedly.
+     */
+    private async removeDuplicateItems(collection: Collection<Item<T>>): Promise<void> {
+        const groups = await collection.aggregate<{ _id: T, ids: ObjectId[] }>([
+            { $sort: { complete: -1, timestamp: -1, _id: 1 } },
+            { $group: { _id: '$id', ids: { $push: '$_id' } } },
+            { $match: { 'ids.1': { $exists: true } } }
+        ]).toArray();
+        for (const group of groups) {
+            const extraIds = group.ids.slice(1);
+            if (extraIds.length > 0) {
+                await collection.deleteMany({ _id: { $in: extraIds } });
+            }
+        }
     }
 }

--- a/src/storage/mongodb-throttle-store.spec.ts
+++ b/src/storage/mongodb-throttle-store.spec.ts
@@ -1,0 +1,161 @@
+/*
+ * Copyright 2026 IROHA LAB
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import { Expect, Setup, SetupFixture, Teardown, Test, TestFixture } from 'alsatian';
+import { fail } from 'assert';
+import { Container } from 'inversify';
+import { MongoClient } from 'mongodb';
+import { DatabaseService } from '../service/database-service';
+import { MongoClientProvider } from '../service/mongo-client-provider';
+import { FakeConfigManager } from '../test/fake-config';
+import { ThrottleStore, TYPES_IDX } from '../TYPES_IDX';
+import { MongodbThrottleStore } from './mongodb-throttle-store';
+import { ConfigManager } from '../utils/config-manager';
+import { Sentry, TYPES } from '@irohalab/mira-shared';
+import { FakeSentry } from '../test/FakeSentry';
+
+@TestFixture('MongodbThrottleStore test spec')
+export class MongodbThrottleStoreSpec {
+    private _store: MongodbThrottleStore;
+    private _config: ConfigManager;
+    private _container: Container;
+    private _databaseService: DatabaseService;
+    private _mongoClientProvider: MongoClientProvider;
+
+    private _collectionName: string = 'throttle';
+    private static readonly TEST_MODE = 'test';
+    private dbName: string;
+
+    @SetupFixture
+    public setupFixture() {
+        if (!process.env.DB_NAME) {
+            fail('You must set the Environment Variable DB_NAME to avoid potential damage to default database');
+        }
+        this._container = new Container();
+        this._container.bind<ConfigManager>(TYPES.ConfigManager).to(FakeConfigManager).inSingletonScope();
+        this._container.bind<MongoClientProvider>(MongoClientProvider).toSelf().inSingletonScope();
+        this._container.bind<string>(TYPES_IDX.DBName).toConstantValue(`${MongodbThrottleStoreSpec.TEST_MODE}_indexer`);
+        this._container.bind<DatabaseService>(DatabaseService).toSelf().inSingletonScope();
+        this._container.bind<ThrottleStore>(TYPES_IDX.ThrottleStore).to(MongodbThrottleStore).inTransientScope();
+        this._container.bind<Sentry>(TYPES.Sentry).to(FakeSentry).inSingletonScope();
+        this._config = this._container.get<ConfigManager>(TYPES.ConfigManager);
+        this.dbName = this._container.get(TYPES_IDX.DBName);
+        (this._config as FakeConfigManager).dbPort = 27017;
+    }
+
+    @Setup
+    public async databaseInit(): Promise<void> {
+        this._mongoClientProvider = this._container.get<MongoClientProvider>(MongoClientProvider);
+        await this._mongoClientProvider.connect();
+        this._databaseService = this._container.get<DatabaseService>(DatabaseService);
+        await this._databaseService.onStart();
+        this._store = this._container.get<ThrottleStore>(TYPES_IDX.ThrottleStore) as MongodbThrottleStore;
+    }
+
+    @Teardown
+    public async databaseCleanUp(): Promise<void> {
+        const client = await this._createClient();
+        try {
+            const cur = client.db(this.dbName).listCollections({}, { nameOnly: true });
+            const existCollections = await cur.toArray();
+            for (let collection of existCollections) {
+                await client.db(this.dbName).collection(collection.name).drop();
+            }
+        } finally {
+            await client.close();
+        }
+        await this._mongoClientProvider.close();
+    }
+
+    @Test('Should claim a fresh slot and reject an immediate re-claim')
+    public async claimAndThrottle(): Promise<void> {
+        Expect(await this._store.tryClaimTaskTime('MainTask_test', 10000)).toBe(true);
+        Expect(await this._store.tryClaimTaskTime('MainTask_test', 10000)).toBe(false);
+    }
+
+    @Test('Should allow a re-claim after the interval has elapsed')
+    public async reclaimAfterInterval(): Promise<void> {
+        Expect(await this._store.tryClaimTaskTime('MainTask_test', 50)).toBe(true);
+        await this.sleep(80);
+        Expect(await this._store.tryClaimTaskTime('MainTask_test', 50)).toBe(true);
+    }
+
+    @Test('Distinct names should be claimed independently')
+    public async independentNames(): Promise<void> {
+        Expect(await this._store.tryClaimTaskTime('MainTask_test', 10000)).toBe(true);
+        Expect(await this._store.tryClaimTaskTime('FailedTask_test', 10000)).toBe(true);
+        Expect(await this._store.tryClaimTaskTime('MainTask_test', 10000)).toBe(false);
+    }
+
+    @Test('Should keep a single record per name across repeated claims')
+    public async singleRecordPerName(): Promise<void> {
+        Expect(await this._store.tryClaimTaskTime('MainTask_test', 50)).toBe(true);
+        await this.sleep(80);
+        Expect(await this._store.tryClaimTaskTime('MainTask_test', 50)).toBe(true);
+        const client = await this._createClient();
+        try {
+            const docs = await client.db(this.dbName).collection(this._collectionName)
+                .find({ name: 'MainTask_test' }).toArray();
+            Expect(docs.length).toBe(1);
+        } finally {
+            await client.close();
+        }
+    }
+
+    @Test('Should collapse legacy duplicate records and enforce a unique index')
+    public async dedupeLegacyDuplicates(): Promise<void> {
+        // Simulate duplicate records left by the previous non-atomic implementation.
+        const seedClient = await this._createClient();
+        try {
+            await seedClient.db(this.dbName).collection(this._collectionName).insertMany([
+                { name: 'MainTask_test', timestamp: 1 },
+                { name: 'MainTask_test', timestamp: 2 },
+                { name: 'MainTask_test', timestamp: 3 }
+            ]);
+        } finally {
+            await seedClient.close();
+        }
+
+        // The first claim triggers the one-time dedup + unique index creation. The seeded
+        // timestamps are ancient, so the claim should succeed.
+        Expect(await this._store.tryClaimTaskTime('MainTask_test', 10000)).toBe(true);
+
+        const client = await this._createClient();
+        try {
+            const docs = await client.db(this.dbName).collection(this._collectionName)
+                .find({ name: 'MainTask_test' }).toArray();
+            Expect(docs.length).toBe(1);
+            const indexes = await client.db(this.dbName).collection(this._collectionName).indexes();
+            const hasUniqueNameIndex = indexes.some((ix: any) => ix.unique === true && ix.key && ix.key.name === 1);
+            Expect(hasUniqueNameIndex).toBe(true);
+        } finally {
+            await client.close();
+        }
+    }
+
+    private async _createClient(): Promise<MongoClient> {
+        const url = `mongodb://${this._config.getDbUser()}:${this._config.getDbPass()}@${
+            this._config.getDbHost()
+          }:${this._config.getDbPort()}?authSource=${this._config.getAuthSource()}`;
+        return await MongoClient.connect(url);
+    }
+
+    private sleep(milliseconds: number): Promise<void> {
+        return new Promise((resolve) => {
+            setTimeout(resolve, milliseconds);
+        });
+    }
+}

--- a/src/storage/mongodb-throttle-store.ts
+++ b/src/storage/mongodb-throttle-store.ts
@@ -17,12 +17,9 @@
 import { DatabaseService } from '../service/database-service';
 import { inject, injectable } from 'inversify';
 import { ThrottleStore } from '../TYPES_IDX';
-import { Db } from 'mongodb';
+import { Collection, Db, ObjectId } from 'mongodb';
 import { TYPES } from '@irohalab/mira-shared';
 import { ConfigManager } from '../utils/config-manager';
-
-const MAIN_TASK_RECORD_NAME = 'MainTask';
-const FAILED_TASK_RECORD_NAME = 'FailedTask';
 
 interface ThrottleRecord {
     name: string;
@@ -37,50 +34,113 @@ export class MongodbThrottleStore implements ThrottleStore {
     }
 
     private _throttleCollectionName = 'throttle';
+    private _indexReady: Promise<void> | null = null;
 
     constructor(private _databaseService: DatabaseService,
                 @inject(TYPES.ConfigManager) private _config: ConfigManager) {
         this._databaseService.checkCollection([this._throttleCollectionName]);
     }
 
-    public getLastMainTaskTime(): Promise<number> {
-        return this.getLastTaskTime(MAIN_TASK_RECORD_NAME);
-    }
-
-    public async setLastMainTaskTime(): Promise<void> {
-        await this.setLastTaskTime(MAIN_TASK_RECORD_NAME);
-    }
-
-    public getLastFailedTaskTime(): Promise<number> {
-        return this.getLastTaskTime(FAILED_TASK_RECORD_NAME);
-    }
-
-    public async setLastFailedTaskTime(): Promise<void> {
-        await this.setLastTaskTime(FAILED_TASK_RECORD_NAME);
-    }
-
-    public async getLastTaskTime(name: string): Promise<number> {
-        const record = await this.db.collection<{timestamp: number}>(this._throttleCollectionName).findOne({name});
-        return record ? record.timestamp : 0;
-    }
-
-    public async setLastTaskTime(name: string): Promise<void> {
-        await this.db.collection(this._throttleCollectionName).findOneAndUpdate({name},
-            {$set: {timestamp: Date.now()}}, {upsert: true});
+    /**
+     * Atomically check if enough time has passed and claim the slot.
+     * Returns true if this caller won the claim, false if a recent claim is still active.
+     *
+     * The whole decision is a single atomic `findOneAndUpdate` guarded by a unique index on
+     * `name` (see ensureUniqueIndex):
+     *  - record is stale (timestamp <= threshold) -> filter matches -> update -> claimed;
+     *  - record is absent                          -> upsert inserts -> claimed;
+     *  - record exists but is still recent         -> filter misses -> upsert attempts an
+     *    insert that violates the unique index (E11000) -> not claimed.
+     * Because everything happens in one operation, concurrent callers cannot both claim the
+     * same slot: MongoDB serializes writes to the document, so the loser always hits E11000.
+     */
+    public async tryClaimTaskTime(name: string, minInterval: number): Promise<boolean> {
+        await this.ensureUniqueIndex();
+        const now = Date.now();
+        const threshold = now - minInterval;
+        try {
+            const result = await this.db.collection<ThrottleRecord>(this._throttleCollectionName).findOneAndUpdate(
+                { name, timestamp: { $lte: threshold } },
+                { $set: { name, timestamp: now } },
+                { upsert: true, returnDocument: 'after' }
+            );
+            return result != null;
+        } catch (e: any) {
+            if (e && (e.code === 11000 || e.codeName === 'DuplicateKey')) {
+                // A record already exists and its timestamp is still recent:
+                // another caller holds the claim.
+                return false;
+            }
+            throw e;
+        }
     }
 
     /**
-     * Atomically check if enough time has passed and claim the slot.
-     * Returns true if this instance won the race, false if another instance already claimed it.
+     * Ensure the unique index on `name` exists, running the one-time setup at most once per
+     * process. Memoized; on failure the memo is cleared so a later call can retry.
      */
-    public async tryClaimTaskTime(name: string, minInterval: number): Promise<boolean> {
-        const threshold = Date.now() - minInterval;
-        const result = await this.db.collection(this._throttleCollectionName).findOneAndUpdate(
-            { name, $or: [{ timestamp: { $lte: threshold } }, { timestamp: { $exists: false } }] },
-            { $set: { timestamp: Date.now() } },
-            { upsert: true, returnDocument: 'after' }
-        );
-        // If the update matched and modified, this instance won the race
-        return result != null;
+    private ensureUniqueIndex(): Promise<void> {
+        if (!this._indexReady) {
+            this._indexReady = this.doEnsureUniqueIndex().catch((e) => {
+                this._indexReady = null;
+                throw e;
+            });
+        }
+        return this._indexReady;
+    }
+
+    /**
+     * Collapse legacy duplicate throttle records (created by a previous non-atomic
+     * implementation) into a single record per name, then create the unique index on `name`
+     * that tryClaimTaskTime relies on for atomicity.
+     *
+     * This is safe to run concurrently from multiple processes/machines against the same
+     * MongoDB:
+     *  - createIndex is attempted first; if the index already exists it is a no-op, and once
+     *    ANY process succeeds the unique constraint is enforced server-side for everyone,
+     *    which stops further duplicates from being inserted;
+     *  - if duplicates block index creation, they are removed with a DELETE-ONLY pass that
+     *    keeps a deterministically-chosen record and deletes the extras by their specific
+     *    _id. Deleting an already-deleted _id is a no-op, so concurrent runs cannot recreate
+     *    duplicates or delete the surviving record.
+     */
+    private async doEnsureUniqueIndex(): Promise<void> {
+        const collection = this.db.collection<ThrottleRecord>(this._throttleCollectionName);
+        const maxAttempts = 5;
+        for (let attempt = 0; attempt < maxAttempts; attempt++) {
+            try {
+                await collection.createIndex({ name: 1 }, { unique: true });
+                return;
+            } catch (e: any) {
+                if (!(e && (e.code === 11000 || e.codeName === 'DuplicateKey'))) {
+                    throw e;
+                }
+                // Duplicates block the unique index (possibly re-created by a concurrent
+                // claim while the index did not yet exist). Remove the extras and retry.
+                await this.removeDuplicateRecords(collection);
+            }
+        }
+        // Final attempt: surface the error if duplicates still somehow persist.
+        await collection.createIndex({ name: 1 }, { unique: true });
+    }
+
+    /**
+     * Delete-only de-duplication: for every name with more than one record, keep the record
+     * with the newest timestamp (ties broken by _id so the choice is deterministic across
+     * machines) and delete the others by their specific _id. Never inserts, so it is
+     * idempotent and safe under concurrent execution.
+     */
+    private async removeDuplicateRecords(collection: Collection<ThrottleRecord>): Promise<void> {
+        const groups = await collection.aggregate<{ _id: string, ids: ObjectId[] }>([
+            { $sort: { timestamp: -1, _id: 1 } },
+            { $group: { _id: '$name', ids: { $push: '$_id' } } },
+            { $match: { 'ids.1': { $exists: true } } }
+        ]).toArray();
+        for (const group of groups) {
+            const extraIds = group.ids.slice(1);
+            if (extraIds.length > 0) {
+                await collection.deleteMany({ _id: { $in: extraIds } });
+            }
+        }
     }
 }

--- a/src/task/task-orchestra.spec.ts
+++ b/src/task/task-orchestra.spec.ts
@@ -76,6 +76,10 @@ export class TaskOrchestraSpec {
             fakeResources.push(res);
         }
         this._scraper.resources = fakeResources;
+        // Register exchanges/queues/publications with the broker (as ScraperCoordinator does
+        // in production) before starting; otherwise publishing the first task fails with
+        // "Unknown publication".
+        await this._scraper.initMQ();
         await this._scraper.start();
     }
 

--- a/src/task/task-orchestra.ts
+++ b/src/task/task-orchestra.ts
@@ -25,7 +25,8 @@ import {
     TYPES_IDX
 } from '../TYPES_IDX';
 import { TaskStatus } from './task-status';
-import { CommonTask, Task, TaskType } from './task-types';
+import { Task, TaskType } from './task-types';
+import { MainTask } from './main-task';
 import { logger } from '../utils/logger-factory';
 import { MQMessage, RabbitMQService, TYPES } from '@irohalab/mira-shared';
 import { promisify } from 'util';
@@ -42,12 +43,15 @@ export class TaskOrchestra {
     private _checkFailedTaskTimerId: Timeout;
     private _lastMainTaskExeTime  = 0;
     private _scraper: Scraper;
-    private _lastExeTime = 0;
+    private _lastMainExeTime = 0;
+    private _lastSubExeTime = 0;
     private _vhost = '/';
 
     private readonly _exchangeName: string;
-    private readonly _queueName: string;
-    private readonly _taskRoutingKey: string;
+    private readonly _mainQueueName: string;
+    private readonly _subQueueName: string;
+    private readonly _mainRoutingKey: string;
+    private readonly _subRoutingKey: string;
 
     constructor(@inject(TYPES.ConfigManager) private _config: ConfigManager,
                 @inject(TYPES_IDX.TaskTimingFactory) private _taskTimingFactory: (interval: number) => number,
@@ -55,11 +59,14 @@ export class TaskOrchestra {
                 @inject(TYPES_IDX.TaskStorage) private _taskStore: TaskQueue,
                 @inject(TYPES_IDX.ThrottleStore) private _throttleStore: ThrottleStore,
                 @inject(TYPES_IDX.Mode) private mode: string,
-                @inject(TYPES_IDX.AsyncMutex) @optional() private _mutex: AsyncMutex | null,
+                @inject(TYPES_IDX.MainTaskMutex) @optional() private _mainMutex: AsyncMutex | null,
+                @inject(TYPES_IDX.SubTaskMutex) @optional() private _subMutex: AsyncMutex | null,
                 @inject(TYPES_IDX.MQControlAPIClient) private _mqControlAPI: MQControlAPIClient) {
         this._exchangeName = `${TASK_EXCHANGE}_${this.mode}`;
-        this._queueName = `${TASK_QUEUE}_${this.mode}`;
-        this._taskRoutingKey = `${TASK_ROUTING_KEY}_${this.mode}`;
+        this._mainQueueName = `${TASK_QUEUE}_main_${this.mode}`;
+        this._subQueueName = `${TASK_QUEUE}_sub_${this.mode}`;
+        this._mainRoutingKey = `${TASK_ROUTING_KEY}_main_${this.mode}`;
+        this._subRoutingKey = `${TASK_ROUTING_KEY}_sub_${this.mode}`;
         if (this._config.amqpServerUrl()) {
             const urlObj = new URL(this._config.amqpServerUrl());
             this._vhost = urlObj.pathname.substring(1);
@@ -72,26 +79,49 @@ export class TaskOrchestra {
      * because RascalImpl creates the broker lazily on the first consume().
      */
     public async initMQ(): Promise<void> {
-        if (this._mutex) {
-            this._mutex.registerMode(this.mode);
+        if (this._mainMutex) {
+            this._mainMutex.registerMode(this.mode);
         }
-        await this._mqService.initPublisher(this._exchangeName, 'direct', this._taskRoutingKey);
-        await this._mqService.initConsumer(this._exchangeName, 'direct', this._queueName, this._taskRoutingKey);
+        if (this._subMutex) {
+            this._subMutex.registerMode(this.mode);
+        }
+        await this._mqService.initPublisher(this._exchangeName, 'direct', this._mainRoutingKey);
+        await this._mqService.initPublisher(this._exchangeName, 'direct', this._subRoutingKey);
+        await this._mqService.initConsumer(this._exchangeName, 'direct', this._mainQueueName, this._mainRoutingKey);
+        await this._mqService.initConsumer(this._exchangeName, 'direct', this._subQueueName, this._subRoutingKey);
     }
 
     public async start(scraper: Scraper): Promise<void> {
-        let actualInterval = this._taskTimingFactory(this._config.getMinInterval());
+        const actualInterval = this._taskTimingFactory(this._config.getMinInterval());
         this._scraper = scraper;
-        await this._mqService.consume(this._queueName, async (msg: MQMessage) => {
+        await this._mqService.consume(this._mainQueueName, this.makeConsumer(true, actualInterval));
+        await this._mqService.consume(this._subQueueName, this.makeConsumer(false, actualInterval));
+        await this.checkMainTask(actualInterval);
+        await this.checkFailedTask();
+    }
+
+    /**
+     * Build a consumer callback bound to a lane (main or sub). Each lane has its own mutex and
+     * its own execution throttle, so at most one main task and one sub task run at any time
+     * across all modes.
+     */
+    private makeConsumer(isMain: boolean, actualInterval: number): (msg: MQMessage) => Promise<boolean> {
+        const mutex = isMain ? this._mainMutex : this._subMutex;
+        return async (msg: MQMessage) => {
             const task = msg as Task;
             const executeTask = async () => {
                 const currentTime = Date.now();
-                if (currentTime < this._lastExeTime + actualInterval) {
+                const lastExeTime = isMain ? this._lastMainExeTime : this._lastSubExeTime;
+                if (currentTime < lastExeTime + actualInterval) {
                     await sleep(2000);
                     return false;
                 }
-                this._lastExeTime = Date.now();
-                let result = await this._scraper.executeTask(task);
+                if (isMain) {
+                    this._lastMainExeTime = Date.now();
+                } else {
+                    this._lastSubExeTime = Date.now();
+                }
+                const result = await this._scraper.executeTask(task);
                 if (result === TaskStatus.NeedRetry) {
                     await this._taskStore.offerFailedTask(task);
                 } else if (result === TaskStatus.Success && task.type === TaskType.MAIN) {
@@ -99,18 +129,32 @@ export class TaskOrchestra {
                 }
                 return true;
             };
-            if (this._mutex) {
-                return await this._mutex.runExclusive(this.mode, executeTask);
-            } else {
-                return await executeTask();
+            try {
+                if (mutex) {
+                    return await mutex.runExclusive(this.mode, executeTask);
+                } else {
+                    return await executeTask();
+                }
+            } catch (err: any) {
+                // An unexpected error escaped task execution (e.g. a storage failure).
+                // We must settle the message; otherwise, with prefetch=1, the unacked message
+                // permanently stalls this queue's consumer. We don't know how to handle it,
+                // so drop it by acking (return true). Undiscovered items will be re-queued by
+                // the next main task run.
+                logger.error('consumer_task_error', {
+                    mode: this.mode,
+                    taskType: task.type,
+                    message: err.message,
+                    stack: err.stack
+                });
+                return true;
             }
-        });
-        await this.checkMainTask(actualInterval);
-        await this.checkFailedTask();
+        };
     }
 
     public async queue(task: Task): Promise<void> {
-        await this._mqService.publish(this._exchangeName, this._taskRoutingKey, task);
+        const routingKey = task.type === TaskType.MAIN ? this._mainRoutingKey : this._subRoutingKey;
+        await this._mqService.publish(this._exchangeName, routingKey, task);
     }
 
     public stop() {
@@ -120,25 +164,18 @@ export class TaskOrchestra {
 
     private async checkMainTask(actualInterval: number): Promise<void> {
         try {
-            const queueInfo = await this._mqControlAPI.getQueueInfo(this._vhost, this._queueName);
+            // The main queue only ever holds a few pagination tasks, so this guard just avoids
+            // stacking a new discovery while pagination is still in flight; it can never be
+            // starved by the (separate) sub-task backlog.
+            const queueInfo = await this._mqControlAPI.getQueueInfo(this._vhost, this._mainQueueName);
             if (queueInfo.len > 0) {
-                logger.info('skip_main_task_check', { mode: this.mode, queueLen: queueInfo.len });
+                logger.info('skip_main_task_seed', { mode: this.mode, queueLen: queueInfo.len });
             } else {
-                const executeMainTask = async () => {
-                    const currentTime = Date.now();
-                    if (currentTime < this._lastExeTime + actualInterval) {
-                        return;
-                    }
-                    const claimed = await this._throttleStore.tryClaimTaskTime(`MainTask_${this.mode}`, this._config.getMinCheckInterval());
-                    if (claimed) {
-                        this._lastExeTime = Date.now();
-                        await this._scraper.executeTask(new CommonTask(TaskType.MAIN));
-                    }
-                };
-                if (this._mutex) {
-                    await this._mutex.runExclusive(this.mode, executeMainTask);
-                } else {
-                    await executeMainTask();
+                const claimed = await this._throttleStore.tryClaimTaskTime(`MainTask_${this.mode}`, this._config.getMinCheckInterval());
+                if (claimed) {
+                    // Seed a page-1 main task; the main consumer executes it (and pagination)
+                    // under the main lane.
+                    await this.queue(new MainTask(TaskType.MAIN));
                 }
             }
         } catch (err: any) {
@@ -152,18 +189,16 @@ export class TaskOrchestra {
     }
 
     private async checkFailedTask(): Promise<void> {
-        const executeFailedTaskCheck = async () => {
+        try {
             const claimed = await this._throttleStore.tryClaimTaskTime(`FailedTask_${this.mode}`, this._config.getMinFailedTaskCheckInterval());
             if (claimed) {
                 while (await this.pickFailedTask()) {
                     await sleep(1000);
                 }
             }
-        };
-        if (this._mutex) {
-            await this._mutex.runExclusive(this.mode, executeFailedTaskCheck);
-        } else {
-            await executeFailedTaskCheck();
+        } catch (err: any) {
+            // Never let an error skip the reschedule below, otherwise the retry loop dies.
+            logger.warn('check_failed_task_iteration_error', { mode: this.mode, message: err.message, stack: err.stack });
         }
         const checkInterval = this._taskTimingFactory(this._config.getMinFailedTaskCheckInterval() / 2);
         this._checkFailedTaskTimerId = setTimeout(() => {
@@ -181,7 +216,10 @@ export class TaskOrchestra {
         if (await this._taskStore.hasFailedTask()) {
             let task = await this._taskStore.pollFailedTask();
             if (task.retryCount > this._config.getMaxRetryCount()) {
-                // drop task
+                // drop task; release any reservation so the item can be rediscovered later.
+                if (this._scraper.handleDroppedTask) {
+                    await this._scraper.handleDroppedTask(task);
+                }
                 logger.warn('drop_task', {
                     mode: this.mode,
                     task

--- a/src/test/in-memory-item-store.ts
+++ b/src/test/in-memory-item-store.ts
@@ -47,6 +47,14 @@ export class InMemoryItemStore<T> implements ItemStorage<T> {
         return Promise.resolve(true);
     }
 
+    public reserveItem(item: Item<T>): Promise<boolean> {
+        if (this._itemTable.has(item.id)) {
+            return Promise.resolve(false);
+        }
+        this._itemTable.set(item.id, item);
+        return Promise.resolve(true);
+    }
+
     public searchItem(keyword: string): Promise<Item<T>[]> {
         return undefined;
     }

--- a/src/test/in-memory-throttle-store.ts
+++ b/src/test/in-memory-throttle-store.ts
@@ -19,34 +19,12 @@ import { injectable } from 'inversify';
 
 @injectable()
 export class InMemoryThrottleStore implements ThrottleStore {
-    tasks: { [key: string]:  number};
-    constructor() {
-        this.tasks = {
-            main: 0,
-            failed: 0
-        };
-    }
-
-    getLastMainTaskTime(): Promise<number> {
-        return Promise.resolve(this.tasks.main);
-    }
-    setLastMainTaskTime(): Promise<void> {
-        this.tasks.main = Date.now();
-        return Promise.resolve();
-    }
-    getLastFailedTaskTime(): Promise<number> {
-        return Promise.resolve(this.tasks.failed);
-    }
-    setLastFailedTaskTime(): Promise<void> {
-        this.tasks.failed = Date.now();
-        return Promise.resolve();
-    }
+    private _lastClaims: Map<string, number> = new Map();
 
     tryClaimTaskTime(name: string, minInterval: number): Promise<boolean> {
-        const key = name === 'MainTask' ? 'main' : 'failed';
-        const last = this.tasks[key];
+        const last = this._lastClaims.get(name) || 0;
         if (Date.now() - last >= minInterval) {
-            this.tasks[key] = Date.now();
+            this._lastClaims.set(name, Date.now());
             return Promise.resolve(true);
         }
         return Promise.resolve(false);


### PR DESCRIPTION
## Summary

Reworks the scraper task orchestration to fix intermittent **missing items** and to
harden reliability, and adds multi-architecture (x86-64 / arm64) image builds.
Bumps the package to **v3.0.0** (queue topology + storage indexes change — see Deploy notes).

## Motivation

We observed items intermittently missing from some source sites even though the
sites still listed them. Root-causing surfaced several issues in the single-queue,
single-mutex design introduced by the earlier "one container for all modes" refactor:

- A single unhandled exception in a consumer callback (e.g. a transient Mongo error)
  left the message unacked and, with `prefetch: 1`, **permanently stalled** that mode's
  consumer.
- The periodic main task was **skipped whenever the shared queue was non-empty**, so a
  large sub-task backlog starved new-item discovery indefinitely.
- A pagination regression meant the periodic check only ever scraped page 1.
- Duplicate detection depended on the main task never running until the queue drained;
  `putItem` used `insertOne` with no unique index, so any race produced **duplicate item
  documents**.
- `tryClaimTaskTime` used an upsert that inserted duplicate throttle records and always
  returned `true`.
- An exception in `checkFailedTask` could permanently kill the failed-task retry loop.

## Changes

### Reliability fixes
- Consumer callbacks always settle the message: on an unexpected error they log and ack
  (drop) instead of throwing, so a single failure can never wedge the queue.
- Fixed the pagination regression (periodic discovery now paginates correctly).
- `checkFailedTask` is wrapped so an error can no longer stop its reschedule loop.

### Deduplication (correctness independent of queue depth)
- Added a **unique index on `items.id`** (created on first use, with a one-time delete-only
  dedup of any legacy duplicate docs).
- **Reserve-on-discovery**: the main task atomically reserves an item (`complete: false`
  stub) before queuing its sub task, so re-discovery can't enqueue a duplicate.
- `putItem` now upserts and marks the item `complete: true`; `searchItem` hides incomplete
  stubs; permanently-dropped sub tasks delete their reservation so the item can be
  rediscovered.
- Rewrote `tryClaimTaskTime` as a single atomic `findOneAndUpdate` guarded by a **unique
  index on `throttle.name`** (with concurrency-safe legacy dedup). Removed dead
  `get/setLast*TaskTime` methods.

### Two-queue orchestration
- Each mode now uses **two queues** on one exchange: `task_queue_main_${mode}` and
  `task_queue_sub_${mode}`, with type-based routing (failed tasks re-route by type).
- **Two global mutex lanes** (`MainTaskMutex` / `SubTaskMutex`) cap concurrency at
  1 main + 1 sub across all modes, each with its own execution throttle.
- `checkMainTask` is now a lightweight heartbeat that seeds a page-1 main task when the
  (tiny) main queue is empty — discovery can no longer be starved by the sub backlog.

### Build
- Added multi-architecture image builds (x86-64 + arm64) to the release workflow.

### Tests
- Added specs for `reserveItem`/`putItem`/`deleteItem`/dedup (item store) and for the
  atomic claim + legacy dedup (throttle store); fixed the in-memory throttle fake to key
  by full name; corrected `env-test.sh` to load only spec files; task-orchestra spec now
  calls `initMQ()` before `start()`.

## Deploy notes (breaking — hence v3.0.0)
- **Queue names change.** Messages left in the old `task_queue_${mode}` at deploy time are
  orphaned; they self-heal because affected items are simply rediscovered by the next main
  run (thanks to reservations). No manual migration required.
- On first run, unique indexes are auto-created on `items.id` and `throttle.name`; existing
  **duplicate documents are collapsed** (extras deleted). Consider snapshotting those
  collections before rollout.

## Testing
- `tsc --noEmit` clean.
- Unit specs pass against local MongoDB + RabbitMQ (`./env-test.sh`).
- Verified locally end-to-end: main discovery proceeds under a large sub backlog, no
  duplicate item documents, and dropped items reappear on rediscovery.