### PR TITLE
Fix the oom issue for removeDuplicate

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "indexer",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "scripts": {
     "clean:dist": "rimraf dist/*",
     "build": "npm run clean:dist && tsc && cp package.json dist",

--- a/src/storage/mongodb-item-store.ts
+++ b/src/storage/mongodb-item-store.ts
@@ -167,13 +167,22 @@ export class MongodbItemStore<T> implements ItemStorage<T> {
      * idempotent and safe to run repeatedly.
      */
     private async removeDuplicateItems(collection: Collection<Item<T>>): Promise<void> {
-        const groups = await collection.aggregate<{ _id: T, ids: ObjectId[] }>([
-            { $sort: { complete: -1, timestamp: -1, _id: 1 } },
-            { $group: { _id: '$id', ids: { $push: '$_id' } } },
-            { $match: { 'ids.1': { $exists: true } } }
+        // First pass: find only the business ids that have more than one document.
+        // This group-only aggregation needs no $sort over the full collection.
+        const duplicateIds = await collection.aggregate<{ _id: T }>([
+            { $group: { _id: '$id', count: { $sum: 1 } } },
+            { $match: { count: { $gt: 1 } } }
         ]).toArray();
-        for (const group of groups) {
-            const extraIds = group.ids.slice(1);
+
+        // Second pass: for each duplicated id (typically a tiny set), sort only those
+        // few documents and delete all but the best one (complete desc, timestamp desc).
+        for (const { _id: id } of duplicateIds) {
+            const docs = await collection
+                .find({ id } as any)
+                .sort({ complete: -1, timestamp: -1, _id: 1 })
+                .project({ _id: 1 })
+                .toArray();
+            const extraIds = docs.slice(1).map(d => d._id);
             if (extraIds.length > 0) {
                 await collection.deleteMany({ _id: { $in: extraIds } });
             }


### PR DESCRIPTION
The old pipeline sorted the entire collection before grouping, which is O(N log N) over all documents. The new approach:

First aggregation — $group + $match with no $sort: finds only the duplicate id values, touching each document once without sorting.
Per-id queries — sorts only the small set of documents sharing a given id (typically 2–3), so no sort ever approaches the memory limit.
Once the index is successfully created after this cleanup, the unique constraint prevents new duplicates from forming, so this code path won't be hit again.

